### PR TITLE
Don’t erase text behind a sixel image; the image might be transparent

### DIFF
--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1810,8 +1810,6 @@ impl<T: EventListener> Handler for Term<T> {
 
         let left = if scrolling { self.grid.cursor.point.column.0 } else { 0 };
 
-        let graphic_columns = (graphic.width + self.cell_width - 1) / self.cell_width;
-
         let texture = Arc::new(TextureRef {
             id: graphic_id,
             remove_queue: Arc::downgrade(&self.graphics.remove_queue),

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1803,13 +1803,14 @@ impl<T: EventListener> Handler for Term<T> {
 
         // Fill the cells under the graphic.
         //
-        // The cell in the first column contains a reference to the graphic,
-        // with the offset from the start. Rest of the cells are empty.
+        // The cell in the first column contains a reference to the
+        // graphic, with the offset from the start. The rest of the
+        // cells are not overwritten, allowing any text behind
+        // transparent portions of the image to be visible.
 
         let left = if scrolling { self.grid.cursor.point.column.0 } else { 0 };
 
         let graphic_columns = (graphic.width + self.cell_width - 1) / self.cell_width;
-        let right = min(self.columns(), left + graphic_columns);
 
         let texture = Arc::new(TextureRef {
             id: graphic_id,
@@ -1830,13 +1831,9 @@ impl<T: EventListener> Handler for Term<T> {
 
             // Store a reference to the graphic in the first column.
             let graphic_cell = GraphicCell { texture: texture.clone(), offset_x: 0, offset_y };
-            let mut cell = Cell::default();
+            let mut cell = self.grid[line][Column(left)].clone();
             cell.set_graphic(graphic_cell);
             self.grid[line][Column(left)] = cell;
-
-            for col in left + 1..right {
-                self.grid[line][Column(col)] = Cell::default();
-            }
 
             if scrolling {
                 self.linefeed();


### PR DESCRIPTION
We still add a reference to the graphic in the first cell of every
line under the image, but we don’t erase any of the text in any of the
cells.

I’m sad to admit how long it took me to find this fix. I had seen the code a few days ago, but just now I was bored and looking in my fridge for a snack when it occurred to me that this was the source of the bug.

Here’s what it looks like on the test case from that one foot bug:

![Screenshot from 2021-05-30 23-20-47](https://user-images.githubusercontent.com/228849/120149123-cb218380-c1d8-11eb-821f-daffdac95181.png)
