### PR TITLE
CellExtra now holds a Vec of graphics to draw

### DIFF
--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -187,7 +187,7 @@ impl<'a> Iterator for RenderableContent<'a> {
 pub struct RenderableCell {
     pub character: char,
     pub zerowidth: Option<Vec<char>>,
-    pub graphic: Option<GraphicCell>,
+    pub graphic: Option<Vec<GraphicCell>>,
     pub point: Point<usize>,
     pub fg: Rgb,
     pub bg: Rgb,
@@ -259,7 +259,7 @@ impl RenderableCell {
 
         RenderableCell {
             zerowidth: cell.zerowidth().map(|zerowidth| zerowidth.to_vec()),
-            graphic: cell.graphic().cloned(),
+            graphic: cell.graphics().map(|s| s.to_owned()),
             flags: cell.flags,
             character,
             bg_alpha,

--- a/alacritty/src/renderer/graphics/draw.rs
+++ b/alacritty/src/renderer/graphics/draw.rs
@@ -38,20 +38,22 @@ impl RenderList {
     /// The graphic is added only the first time it is found in a cell.
     #[inline]
     pub fn update(&mut self, cell: &RenderableCell) {
-        if let Some(graphic) = &cell.graphic {
-            let graphic_id = graphic.graphic_id();
-            if self.items.contains_key(&graphic_id) {
-                return;
+        if let Some(graphics) = &cell.graphic {
+            for graphic in graphics {
+                let graphic_id = graphic.graphic_id();
+                if self.items.contains_key(&graphic_id) {
+                    return;
+                }
+
+                let render_item = RenderPosition {
+                    column: cell.point.column,
+                    line: cell.point.line,
+                    offset_x: graphic.offset_x,
+                    offset_y: graphic.offset_y,
+                };
+
+                self.items.insert(graphic_id, render_item);
             }
-
-            let render_item = RenderPosition {
-                column: cell.point.column,
-                line: cell.point.line,
-                offset_x: graphic.offset_x,
-                offset_y: graphic.offset_y,
-            };
-
-            self.items.insert(graphic_id, render_item);
         }
     }
 

--- a/alacritty_terminal/src/graphics/mod.rs
+++ b/alacritty_terminal/src/graphics/mod.rs
@@ -96,6 +96,9 @@ pub struct GraphicData {
 
     /// Pixels data.
     pub pixels: Vec<u8>,
+
+    /// This image deletes existing images at the same location
+    pub delete: bool,
 }
 
 /// Queues to add or to remove the textures in the display.

--- a/alacritty_terminal/src/term/cell.rs
+++ b/alacritty_terminal/src/term/cell.rs
@@ -111,6 +111,13 @@ impl Cell {
         self.extra.as_deref().and_then(|extra| extra.graphic.as_deref())
     }
 
+    /// Remove graphic data from the cell.
+    #[inline]
+    pub fn remove_graphics(&mut self) {
+        self.extra.as_mut().and_then(|extra: &mut Box<CellExtra>| extra.graphic.as_mut().and_then(|graphic: &mut Vec<GraphicCell>| { graphic.clear(); Some(graphic) }));
+        self.flags_mut().remove(Flags::GRAPHICS);
+    }
+
     /// Write the graphic data in the cell.
     #[inline]
     pub fn set_graphic(&mut self, graphic_cell: GraphicCell) {

--- a/alacritty_terminal/src/term/cell.rs
+++ b/alacritty_terminal/src/term/cell.rs
@@ -57,7 +57,7 @@ struct CellExtra {
     zerowidth: Vec<char>,
 
     #[serde(skip)]
-    graphic: Option<Box<GraphicCell>>,
+    graphic: Option<Vec<GraphicCell>>,
 }
 
 /// Content and attributes of a single cell in the terminal grid.
@@ -107,15 +107,15 @@ impl Cell {
 
     /// Graphic present in the cell.
     #[inline]
-    pub fn graphic(&self) -> Option<&GraphicCell> {
+    pub fn graphics(&self) -> Option<&[GraphicCell]> {
         self.extra.as_deref().and_then(|extra| extra.graphic.as_deref())
     }
 
     /// Write the graphic data in the cell.
     #[inline]
     pub fn set_graphic(&mut self, graphic_cell: GraphicCell) {
-        let mut extra = self.extra.get_or_insert_with(Default::default);
-        extra.graphic = Some(Box::new(graphic_cell));
+        let extra = self.extra.get_or_insert_with(Default::default);
+        extra.graphic.get_or_insert_with(Default::default).push(graphic_cell);
 
         self.flags_mut().insert(Flags::GRAPHICS);
     }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1807,7 +1807,7 @@ impl<T: EventListener> Handler for Term<T> {
         let width = graphic.width as u16;
         let height = graphic.height as u16;
 
-        if width == 0 || height == 0 {
+        if (width == 0 || height == 0) && !graphic.delete {
             return;
         }
 
@@ -1850,6 +1850,11 @@ impl<T: EventListener> Handler for Term<T> {
 
                 Line(top)
             };
+
+            // Possibly delete any existing graphics
+            if graphic.delete {
+                self.grid[line][Column(left)].remove_graphics();
+            }
 
             // Store a reference to the graphic in the first column.
             let graphic_cell = GraphicCell { texture: texture.clone(), offset_x: 0, offset_y };


### PR DESCRIPTION
Multiple graphics with transparency are rendered nicely, just so long as they weren’t started in the same cell. This removes the restriction, allowing multiple graphics to be stacked even if they start in the same cell.

Here’s a test script:

```bash
#!/bin/bash

unset REPLY
IFS=';' read -p $'\e[14t' -a REPLY -rsdt;
screen_height=${REPLY[1]}
unset REPLY
IFS=';' read -p $'\e[18t' -a REPLY -rsdt;
lines=${REPLY[1]}
unset REPLY
line_height=$((screen_height / lines))
height_in_lines=$((300 / line_height))

tput sc

printf '\eP;1q'         # Start Sixel
printf '"1;1;200;200'   # Set raster size to 200x200
printf '#0;2;100;0;100' # Set register 0 to magenta

for N in {1..15}        # 15 green lines of varying length, with 2 empty lines between them
do                      # the first empty line is 300 pixels of ?, the second empty line is skipped
    x1=$((N*300/15))
    x2=$((300-x1))
    printf "#0!${x1}?"  # some transparent pixels
    printf "#3!${x2}~-" # some solid green pixels on the same line
    printf "#0!300?-"   # next line is transparent
    printf "-"          # final line is skipped, and therefore also transparent
done

printf '\e\\'           # End Sixel

# move back to the start of the image, so that the next image overlaps it.
tput rc

printf '\eP;1q'         # Start Sixel
printf '"1;1;200;200'   # Set raster size to 200x200
printf '#0;2;100;0;100' # Set register 0 to magenta
printf '#1;2;0;60;60'   # Set register 1 to dark cyan

for N in {1..15}        # 15 cyan lines of varying length, with 2 empty lines between them
do                      # the first empty line is 300 pixels of ?, the second empty line is skipped
    x1=$((N*300/15))
    x2=$((300-x1))
    printf "#0!${x1}?"  # some transparent pixels
    printf "#1!${x2}w-" # some solid cyan pixels on the same line
    printf "#0!300?-"   # next line is transparent
    printf "-"          # final line is skipped, and therefore also transparent
done
```

Without the patch, the cyan lines overwrite the green ones, but with the patch both the cyan and green lines are shown.

As I said in the commit comment, a SmallVec<GraphicsCell> might be slightly better, but I think it would require performance measurements to know for sure.