### PR TITLE
support DECSET/DECRST (CSI ? Pm h) to change where the cursor ends up

### DIFF
--- a/alacritty_terminal/src/ansi.rs
+++ b/alacritty_terminal/src/ansi.rs
@@ -569,6 +569,8 @@ pub enum Mode {
     SixelPrivateColorRegisters = 1070,
     /// ?2004
     BracketedPaste = 2004,
+    /// Sixel scrolling leaves cursor to right of graphic.
+    SixelCursorToTheRight = 8452,
 }
 
 impl Mode {
@@ -600,6 +602,7 @@ impl Mode {
                 1049 => Mode::SwapScreenAndSetRestoreCursor,
                 1070 => Mode::SixelPrivateColorRegisters,
                 2004 => Mode::BracketedPaste,
+                8452 => Mode::SixelCursorToTheRight,
                 _ => {
                     trace!("[unimplemented] primitive mode: {}", num);
                     return None;

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -46,7 +46,7 @@ const TITLE_STACK_MAX_DEPTH: usize = 4096;
 const INITIAL_TABSTOPS: usize = 8;
 
 bitflags! {
-    pub struct TermMode: u64 {
+    pub struct TermMode: u32 {
         const NONE                = 0;
         const SHOW_CURSOR         = 0b0000_0000_0000_0000_0001;
         const APP_CURSOR          = 0b0000_0000_0000_0000_0010;
@@ -70,7 +70,7 @@ bitflags! {
         const SIXEL_SCROLLING     = 0b0100_0000_0000_0000_0000;
         const SIXEL_PRIV_PALETTE  = 0b1000_0000_0000_0000_0000;
         const SIXEL_CURSOR_TO_THE_RIGHT  = 0b0001_0000_0000_0000_0000_0000;
-        const ANY                 = std::u64::MAX;
+        const ANY                 = std::u32::MAX;
     }
 }
 

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -1869,8 +1869,7 @@ impl<T: EventListener> Handler for Term<T> {
 
         if self.mode.contains(TermMode::SIXEL_CURSOR_TO_THE_RIGHT) {
             let graphic_columns = (graphic.width + self.cell_width - 1) / self.cell_width;
-            let right = min(self.columns(), left + graphic_columns);
-            self.move_forward(Column(right));
+            self.move_forward(Column(graphic_columns));
         } else if scrolling {
             self.linefeed();
             self.carriage_return();

--- a/docs/escape_support.md
+++ b/docs/escape_support.md
@@ -57,7 +57,7 @@ brevity.
 | `CSI ? h`  | PARTIAL     | Supported modes:                                  |
 |            |             |   `1`, `3`, `6`, `7`, `12`, `25`, `1000`, `1002`  |
 |            |             |   `1004`, `1005`, `1006`, `1007`, `1042`, `1049`  |
-|            |             |   `2004`                                          |
+|            |             |   `2004`, `8452`                                  |
 | `CSI I`    | IMPLEMENTED |                                                   |
 | `CSI J`    | IMPLEMENTED |                                                   |
 | `CSI K`    | IMPLEMENTED |                                                   |


### PR DESCRIPTION
after printing a sixel image. The default is for the cursor to be
moved to the first column of the line after the image. When we receive
CSI ? 8452 h, we will instead leave the cursor on the last line of the
image, on the next column past the end of the image.