### PR TITLE
Force using the same utf8parse everywhere

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ resolver = "2"
 lto = "thin"
 debug = 1
 incremental = false
+
+[patch.crates-io]
+utf8parse = { git="https://github.com/ayosec/vte-graphics.git", branch="graphics"}


### PR DESCRIPTION
This prevents the following `cargo vendor` conflict:

```shell-session
> cargo vendor
error: failed to sync

Caused by:
  found duplicate version of package `utf8parse v0.2.1` vendored from two sources:

  	source 1: registry `crates-io`
  	source 2: https://github.com/ayosec/vte-graphics.git?branch=graphics#8caae0d3
```

This is needed to be able to package this on gentoo (as a live ebuild), where the packaging system prevents all build-time network access.

The packaging steps are roughly equivalent to :

```shell
git clone 
cargo fetch 
cargo vendor
cargo build --offline
```

As a side effect, this reduces the size/complexity of the dependency tree