### PR TITLE
Fix sixels position when padding>0

### DIFF
--- a/alacritty/src/renderer/graphics/draw.rs
+++ b/alacritty/src/renderer/graphics/draw.rs
@@ -173,8 +173,8 @@ impl RenderList {
             );
             gl::Uniform2f(
                 renderer.program.u_view_dimensions,
-                size_info.width(),
-                size_info.height(),
+                size_info.width() - 2.0 * size_info.padding_x(),
+                size_info.height() - 2.0 * size_info.padding_y(),
             );
 
             gl::BlendFuncSeparate(gl::SRC_ALPHA, gl::ONE_MINUS_SRC_ALPHA, gl::SRC_ALPHA, gl::ONE);


### PR DESCRIPTION
When alacritty's padding>0, pixels are incorrectly placed. This PR fixes it. Before fix -> after:
![image](https://github.com/ayosec/alacritty/assets/6536835/8f9d8b0f-a4fe-477f-b7e3-3fb97bbf9ef5)
