### PR TITLE
make ready for bump to 0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Notable changes to the `alacritty_terminal` crate are documented in its
 [CHANGELOG](./alacritty_terminal/CHANGELOG.md).
 
-## 0.17.0-dev
+## 0.16.1
 
-### Changed
+### Fixed
 
-- Don't highlight hints on hover when the mouse cursor is hidden
+- Crashes on GPUs with partial robustness support
 
 ## 0.16.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty"
-version = "0.17.0-dev"
+version = "0.16.1"
 dependencies = [
  "ahash",
  "alacritty_config",

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alacritty"
-version = "0.17.0-dev"
+version = "0.16.1"
 authors = ["Christian Duerr <contact@christianduerr.com>", "Joe Wilm <joe@jwilm.com>"]
 license = "Apache-2.0"
 description = "A fast, cross-platform, OpenGL terminal emulator"

--- a/alacritty/src/renderer/platform.rs
+++ b/alacritty/src/renderer/platform.rs
@@ -4,9 +4,9 @@ use std::num::NonZeroU32;
 
 use glutin::config::{ColorBufferType, Config, ConfigTemplateBuilder, GetGlConfig};
 use glutin::context::{
-    ContextApi, ContextAttributesBuilder, GlProfile, NotCurrentContext, Robustness, Version,
+    ContextApi, ContextAttributesBuilder, GlProfile, NotCurrentContext, Version,
 };
-use glutin::display::{Display, DisplayApiPreference, DisplayFeatures, GetGlDisplay};
+use glutin::display::{Display, DisplayApiPreference, GetGlDisplay};
 use glutin::error::Result as GlutinResult;
 use glutin::prelude::*;
 use glutin::surface::{Surface, SurfaceAttributesBuilder, WindowSurface};
@@ -110,12 +110,7 @@ pub fn create_gl_context(
     raw_window_handle: Option<RawWindowHandle>,
 ) -> GlutinResult<NotCurrentContext> {
     let debug = log::max_level() >= LevelFilter::Debug;
-    let mut builder = ContextAttributesBuilder::new().with_debug(debug);
-
-    // Try to enable robustness.
-    if gl_display.supported_features().contains(DisplayFeatures::CONTEXT_ROBUSTNESS) {
-        builder = builder.with_robustness(Robustness::RobustLoseContextOnReset);
-    }
+    let builder = ContextAttributesBuilder::new().with_debug(debug);
 
     let mut profiles = [
         builder

--- a/alacritty/windows/wix/alacritty.wxs
+++ b/alacritty/windows/wix/alacritty.wxs
@@ -1,5 +1,5 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
-   <Package Name="Alacritty" UpgradeCode="87c21c74-dbd5-4584-89d5-46d9cd0c40a7" Language="1033" Codepage="1252" Version="0.17.0-dev" Manufacturer="Alacritty" InstallerVersion="200">
+   <Package Name="Alacritty" UpgradeCode="87c21c74-dbd5-4584-89d5-46d9cd0c40a7" Language="1033" Codepage="1252" Version="0.16.1" Manufacturer="Alacritty" InstallerVersion="200">
       <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
       <Icon Id="AlacrittyIco" SourceFile=".\alacritty\windows\alacritty.ico" />
       <WixVariable Id="WixUILicenseRtf" Value=".\alacritty\windows\wix\license.rtf" />

--- a/extra/osx/Alacritty.app/Contents/Info.plist
+++ b/extra/osx/Alacritty.app/Contents/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.17.0-dev</string>
+  <string>0.16.1</string>
   <key>CFBundleSupportedPlatforms</key>
   <array>
     <string>MacOSX</string>


### PR DESCRIPTION
Since this bumped just looked like there were minor mergeconflicts and the [Nixpkgs](https://github.com/NixOS/nixpkgs/pull/453142) package is currently blocked by this fork lagging behind I thought I'd look into this.

I hope I didn't have a major overlook in this.

@ayosec: please bump a release after merge.
