### PR TITLE
support system light/dark mode switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 - Don't highlight hints on hover when the mouse cursor is hidden
 - IME is disabled in Vi mode on X11
+- Require explicit tap to enable IME with touch input
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 
 - Brief error popup when saving the config file with some editors
 - Subprocesses on OpenBSD now run with their CWD set to that of the shell's foreground process.
+- Crash when OpenGL context resets
 
 ## 0.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 ### Changed
 
 - Don't highlight hints on hover when the mouse cursor is hidden
+- IME is disabled in Vi mode on X11
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Notable changes to the `alacritty_terminal` crate are documented in its
 ### Changed
 
 - Don't highlight hints on hover when the mouse cursor is hidden
-- Require explicit tap to enable IME with touch input
 
 ### Fixed
 

--- a/alacritty/src/config/ui_config.rs
+++ b/alacritty/src/config/ui_config.rs
@@ -75,6 +75,9 @@ pub struct UiConfig {
     /// RGB values for colors.
     pub colors: Colors,
 
+    /// RGB values for colors.
+    pub colors_dark: Colors,
+
     /// Path where config was loaded from.
     #[config(skip)]
     #[serde(skip_serializing)]

--- a/alacritty/src/display/content.rs
+++ b/alacritty/src/display/content.rs
@@ -73,8 +73,17 @@ impl<'a> RenderableContent<'a> {
             None
         };
 
+        let colors = if let Some(theme) = display.window.theme() {
+            match theme {
+                winit::window::Theme::Dark => &display.colors_dark,
+                winit::window::Theme::Light => &display.colors,
+            }
+        } else {
+            &display.colors
+        };
+
         Self {
-            colors: &display.colors,
+            colors,
             size: &display.size_info,
             cursor: RenderableCursor::new_hidden(),
             terminal_content,

--- a/alacritty/src/display/mod.rs
+++ b/alacritty/src/display/mod.rs
@@ -364,6 +364,9 @@ pub struct Display {
     /// Mapped RGB values for each terminal color.
     pub colors: List,
 
+    /// Mapped RGB values for each terminal color.
+    pub colors_dark: List,
+
     /// State of the keyboard hints.
     pub hint_state: HintState,
 
@@ -521,6 +524,7 @@ impl Display {
             renderer_preference: config.debug.renderer,
             surface: ManuallyDrop::new(surface),
             colors: List::from(&config.colors),
+            colors_dark: List::from(&config.colors_dark),
             frame_timer: FrameTimer::new(),
             raw_window_handle,
             damage_tracker,

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -119,9 +119,6 @@ pub struct Window {
 
     is_x11: bool,
     current_mouse_cursor: CursorIcon,
-    text_input_active: bool,
-    pointer_focused: bool,
-    touch_focused: bool,
     mouse_visible: bool,
 }
 
@@ -205,18 +202,15 @@ impl Window {
         let is_x11 = matches!(window.window_handle().unwrap().as_raw(), RawWindowHandle::Xlib(_));
 
         Ok(Self {
-            current_mouse_cursor,
-            scale_factor,
-            is_x11,
-            window,
             hold: options.terminal_options.hold,
             requested_redraw: false,
-            text_input_active: true,
             title: identity.title,
+            current_mouse_cursor,
             mouse_visible: true,
             has_frame: true,
-            pointer_focused: Default::default(),
-            touch_focused: Default::default(),
+            scale_factor,
+            window,
+            is_x11,
         })
     }
 
@@ -439,39 +433,11 @@ impl Window {
         self.window.set_simple_fullscreen(simple_fullscreen);
     }
 
-    /// Set whether plain-text input is currently possible.
-    pub fn set_text_input_active(&mut self, active: bool) {
-        if self.text_input_active != active {
-            self.text_input_active = active;
-            self.update_ime_allowed();
-        }
-    }
-
-    /// Set whether the pointer is currently within the window.
-    pub fn set_pointer_focus(&mut self, focused: bool) {
-        if self.touch_focused != focused {
-            self.touch_focused = focused;
-            self.update_ime_allowed();
-        }
-    }
-
-    /// Set whether a touch action has focused the window.
-    pub fn set_touch_focus(&mut self, focused: bool) {
-        if self.touch_focused != focused {
-            self.touch_focused = focused;
-            self.update_ime_allowed();
-        }
-    }
-
-    /// Update whether IME should be offered.
-    fn update_ime_allowed(&mut self) {
+    pub fn set_ime_allowed(&self, allowed: bool) {
         // Skip runtime IME manipulation on X11 since it breaks some IMEs.
-        if self.is_x11 {
-            return;
+        if !self.is_x11 {
+            self.window.set_ime_allowed(allowed);
         }
-
-        let allowed = self.text_input_active && (self.touch_focused || self.pointer_focused);
-        self.window.set_ime_allowed(allowed);
     }
 
     /// Adjust the IME editor position according to the new location of the cursor.

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -434,10 +434,7 @@ impl Window {
     }
 
     pub fn set_ime_allowed(&self, allowed: bool) {
-        // Skip runtime IME manipulation on X11 since it breaks some IMEs.
-        if !self.is_x11 {
-            self.window.set_ime_allowed(allowed);
-        }
+        self.window.set_ime_allowed(allowed);
     }
 
     /// Adjust the IME editor position according to the new location of the cursor.

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -409,6 +409,10 @@ impl Window {
         self.window.set_theme(theme);
     }
 
+    pub fn theme(&self) -> Option<Theme> {
+        self.window.theme()
+    }
+
     #[cfg(target_os = "macos")]
     pub fn toggle_simple_fullscreen(&self) {
         self.set_simple_fullscreen(!self.window.simple_fullscreen());

--- a/alacritty/src/input/keyboard.rs
+++ b/alacritty/src/input/keyboard.rs
@@ -29,7 +29,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
         if key.state == ElementState::Released {
             if self.ctx.inline_search_state().char_pending {
-                self.ctx.window().set_text_input_active(true);
+                self.ctx.window().set_ime_allowed(true);
             }
             self.key_release(key, mode, mods);
             return;

--- a/alacritty/src/input/keyboard.rs
+++ b/alacritty/src/input/keyboard.rs
@@ -12,6 +12,7 @@ use alacritty_terminal::term::TermMode;
 use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
 
 use crate::config::{Action, BindingKey, BindingMode, KeyBinding};
+use crate::display::window::ImeInhibitor;
 use crate::event::TYPING_SEARCH_DELAY;
 use crate::input::{ActionContext, Execute, Processor};
 use crate::scheduler::{TimerId, Topic};
@@ -29,7 +30,7 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
 
         if key.state == ElementState::Released {
             if self.ctx.inline_search_state().char_pending {
-                self.ctx.window().set_ime_allowed(true);
+                self.ctx.window().set_ime_inhibitor(ImeInhibitor::VI, false);
             }
             self.key_release(key, mode, mods);
             return;

--- a/alacritty/src/input/mod.rs
+++ b/alacritty/src/input/mod.rs
@@ -933,9 +933,6 @@ impl<T: EventListener, A: ActionContext<T>> Processor<T, A> {
                 self.mouse_moved(start_location);
                 self.mouse_input(ElementState::Pressed, MouseButton::Left);
                 self.mouse_input(ElementState::Released, MouseButton::Left);
-
-                // Set touch focus, enabling IME.
-                self.ctx.window().set_touch_focus(true);
             },
             // Transition zoom to pending state once a finger was released.
             TouchPurpose::Zoom(zoom) => {

--- a/alacritty/src/renderer/platform.rs
+++ b/alacritty/src/renderer/platform.rs
@@ -4,9 +4,9 @@ use std::num::NonZeroU32;
 
 use glutin::config::{ColorBufferType, Config, ConfigTemplateBuilder, GetGlConfig};
 use glutin::context::{
-    ContextApi, ContextAttributesBuilder, GlProfile, NotCurrentContext, Version,
+    ContextApi, ContextAttributesBuilder, GlProfile, NotCurrentContext, Robustness, Version,
 };
-use glutin::display::{Display, DisplayApiPreference, GetGlDisplay};
+use glutin::display::{Display, DisplayApiPreference, DisplayFeatures, GetGlDisplay};
 use glutin::error::Result as GlutinResult;
 use glutin::prelude::*;
 use glutin::surface::{Surface, SurfaceAttributesBuilder, WindowSurface};
@@ -110,35 +110,41 @@ pub fn create_gl_context(
     raw_window_handle: Option<RawWindowHandle>,
 ) -> GlutinResult<NotCurrentContext> {
     let debug = log::max_level() >= LevelFilter::Debug;
-    let builder = ContextAttributesBuilder::new().with_debug(debug);
 
-    let mut profiles = [
-        builder
-            .clone()
-            .with_context_api(ContextApi::OpenGl(Some(Version::new(3, 3))))
-            .build(raw_window_handle),
+    let apis = [
+        (ContextApi::OpenGl(Some(Version::new(3, 3))), GlProfile::Core),
         // Try gles before OpenGL 2.1 as it tends to be more stable.
-        builder
-            .clone()
-            .with_context_api(ContextApi::Gles(Some(Version::new(2, 0))))
-            .build(raw_window_handle),
-        builder
-            .with_profile(GlProfile::Compatibility)
-            .with_context_api(ContextApi::OpenGl(Some(Version::new(2, 1))))
-            .build(raw_window_handle),
-    ]
-    .into_iter();
+        (ContextApi::Gles(Some(Version::new(2, 0))), GlProfile::Core),
+        (ContextApi::OpenGl(Some(Version::new(2, 1))), GlProfile::Compatibility),
+    ];
 
-    // Try the optimal config first.
-    let mut picked_context =
-        unsafe { gl_display.create_context(gl_config, &profiles.next().unwrap()) };
+    let robustness = gl_display.supported_features().contains(DisplayFeatures::CONTEXT_ROBUSTNESS);
+    let robustness: &[Robustness] = if robustness {
+        &[Robustness::RobustLoseContextOnReset, Robustness::NotRobust]
+    } else {
+        &[Robustness::NotRobust]
+    };
 
-    // Try the fallback ones.
-    while let (Err(_), Some(profile)) = (picked_context.as_ref(), profiles.next()) {
-        picked_context = unsafe { gl_display.create_context(gl_config, &profile) };
+    // Find the first context that builds without any errors.
+    let mut error = None;
+    for (api, profile) in apis {
+        for robustness in robustness {
+            let attributes = ContextAttributesBuilder::new()
+                .with_debug(debug)
+                .with_context_api(api)
+                .with_profile(profile)
+                .with_robustness(*robustness)
+                .build(raw_window_handle);
+
+            match unsafe { gl_display.create_context(gl_config, &attributes) } {
+                Ok(profile) => return Ok(profile),
+                Err(err) => error = Some(err),
+            }
+        }
     }
 
-    picked_context
+    // If no context was built successfully, return an error for the most permissive one.
+    Err(error.unwrap())
 }
 
 pub fn create_gl_surface(


### PR DESCRIPTION
This patch brings the ability to follow the system theme selection of light or dark theme.

As mentioned in [closed the upstream PR](https://github.com/alacritty/alacritty/pull/8752#issuecomment-3834116403) the original patch author is not interested in bringing this PR here, but gave permission to do so.

For usage I'd like to quote the original author and for an example video see original PR linked above:
> example config:
> 
> ```toml
> [font]
> size = 10
> normal = { family = "Source Code Pro", style = "Regular" }
> bold = { family = "Source Code Pro", style = "SemiBold" }
> italic = { family = "Source Code Pro", style = "Italic" }
> bold_italic = { family = "Source Code Pro", style = "SemiBold Italic" }
> 
> [window]
> resize_increments = true
> opacity = 0.9
> blur = true
> padding = {x=2,y=2}
> dynamic_title = true
> 
> # Colors (Gruvbox dark)
> 
> # Default colors
> [colors_dark.primary]
> # hard contrast background = = '#1d2021'
> background = '#282828'
> # soft contrast background = = '#32302f'
> foreground = '#ebdbb2'
> 
> # Normal colors
> [colors_dark.normal]
> black   = '#282828'
> red     = '#cc241d'
> green   = '#98971a'
> yellow  = '#d79921'
> blue    = '#458588'
> magenta = '#b16286'
> cyan    = '#689d6a'
> white   = '#a89984'
> 
> # Bright colors
> [colors_dark.bright]
> black   = '#928374'
> red     = '#fb4934'
> green   = '#b8bb26'
> yellow  = '#fabd2f'
> blue    = '#83a598'
> magenta = '#d3869b'
> cyan    = '#8ec07c'
> white   = '#ebdbb2'
> 
> # Default colors
> [colors.primary]
> # hard contrast background = = '#f9f5d7'
> background = '#fbf1c7'
> # soft contrast background = = '#f2e5bc'
> foreground = '#3c3836'
> 
> # Normal colors
> [colors.normal]
> black   = '#fbf1c7'
> red     = '#cc241d'
> green   = '#98971a'
> yellow  = '#d79921'
> blue    = '#458588'
> magenta = '#b16286'
> cyan    = '#689d6a'
> white   = '#7c6f64'
> 
> # Bright colors
> [colors.bright]
> black   = '#928374'
> red     = '#9d0006'
> green   = '#79740e'
> yellow  = '#b57614'
> blue    = '#076678'
> magenta = '#8f3f71'
> cyan    = '#427b58'
> white   = '#3c3836'
> ```
