### PR TITLE
Kitty graphics protocol support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+alacritty-debug.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,12 +98,14 @@ version = "0.25.2-dev"
 dependencies = [
  "base64",
  "bitflags 2.9.4",
+ "flate2",
  "home",
  "libc",
  "log",
  "miow",
  "parking_lot",
  "piper",
+ "png",
  "polling",
  "regex-automata",
  "rustix 1.1.2",
@@ -2110,8 +2112,7 @@ dependencies = [
 [[package]]
 name = "vte-graphics"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7d926313d94a0ef0d992fe9ab507451cdb4a7977e653155c8e4fa9b69c178f"
+source = "git+https://github.com/dsturnbull/vte.git?branch=kitty#2e2cea1d96c499c9d1b16c255ce698ac2cd1f59b"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,7 @@ dependencies = [
  "bitflags 2.9.4",
  "flate2",
  "home",
+ "image",
  "libc",
  "log",
  "miow",
@@ -114,9 +115,28 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "smallvec",
+ "tempfile",
  "unicode-width",
  "vte-graphics",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -197,6 +217,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,16 +258,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.17",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
@@ -242,6 +349,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitstream-io"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+dependencies = [
+ "core2",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +365,12 @@ checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
  "objc2 0.5.2",
 ]
+
+[[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
@@ -261,6 +383,12 @@ name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -483,12 +611,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -519,6 +675,12 @@ dependencies = [
  "winapi",
  "yeslogic-fontconfig-sys",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cstr"
@@ -615,6 +777,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +794,26 @@ dependencies = [
  "toml",
  "vswhom",
  "winreg",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -649,6 +837,21 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
 
 [[package]]
 name = "fastrand"
@@ -844,6 +1047,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +1083,28 @@ checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "exr",
+ "moxcms",
+ "num-traits",
+ "png",
+ "ravif",
+ "rayon",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "indexmap"
@@ -901,10 +1137,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -987,10 +1243,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libloading"
@@ -1044,6 +1316,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1381,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1120,6 +1421,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,6 +1464,56 @@ name = "notify-types"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_enum"
@@ -1462,6 +1834,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,11 +1896,11 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "png"
-version = "0.17.16"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.4",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1538,6 +1922,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,6 +1947,37 @@ checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -1580,10 +2004,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand",
+ "rand_chacha",
+ "simd_helpers",
+ "thiserror 2.0.17",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1630,6 +2153,12 @@ name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "rustc_version"
@@ -1825,6 +2354,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +2421,12 @@ checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strict-num"
@@ -2082,6 +2626,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"
@@ -2792,6 +3347,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yeslogic-fontconfig-sys"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2821,4 +3382,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ incremental = false
 [workspace.dependencies]
 toml = "0.9.2"
 toml_edit = "0.23.1"
+
+[patch.crates-io]
+vte-graphics = { git = "https://github.com/dsturnbull/vte.git", branch = "kitty" }

--- a/alacritty/Cargo.toml
+++ b/alacritty/Cargo.toml
@@ -54,7 +54,7 @@ clap_complete = "4.2.3"
 xdg = "3.0.0"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-png = { version = "0.17.5", default-features = false, optional = true }
+png = { version = "0.18", default-features = false, optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.1"

--- a/alacritty/src/display/window.rs
+++ b/alacritty/src/display/window.rs
@@ -301,7 +301,7 @@ impl Window {
             let mut decoder = Decoder::new(Cursor::new(WINDOW_ICON));
             decoder.set_transformations(png::Transformations::normalize_to_color8());
             let mut reader = decoder.read_info().expect("invalid embedded icon");
-            let mut buf = vec![0; reader.output_buffer_size()];
+            let mut buf = vec![0; reader.output_buffer_size().expect("invalid embedded icon size")];
             let _ = reader.next_frame(&mut buf);
             Icon::from_rgba(buf, reader.info().width, reader.info().height)
                 .expect("invalid embedded icon format")

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -17,12 +17,14 @@ serde = ["dep:serde", "bitflags/serde", "vte/serde"]
 [dependencies]
 base64 = "0.22.0"
 bitflags = "2.4.1"
+flate2 = "1.1"
 home = "0.5.5"
 libc = "0.2"
 log = "0.4"
 parking_lot = "0.12.0"
 polling = "3.8.0"
 regex-automata = "0.4.3"
+png = "0.17"
 unicode-width = "0.2.0"
 vte = { version = "0.15.0", package = "vte-graphics", default-features = false, features = ["std", "ansi"] }
 serde = { version = "1", features = ["derive", "rc"], optional = true }

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -24,7 +24,8 @@ log = "0.4"
 parking_lot = "0.12.0"
 polling = "3.8.0"
 regex-automata = "0.4.3"
-png = "0.17"
+image = { version = "0.25", default-features = false, features = ["png", "rayon"] }
+png = "0.18"
 unicode-width = "0.2.0"
 vte = { version = "0.15.0", package = "vte-graphics", default-features = false, features = ["std", "ansi"] }
 serde = { version = "1", features = ["derive", "rc"], optional = true }
@@ -49,3 +50,4 @@ windows-sys = { version = "0.59.0", features = [
 
 [dev-dependencies]
 serde_json = "1.0.0"
+tempfile = "3"

--- a/alacritty_terminal/src/graphics/kitty/animation.rs
+++ b/alacritty_terminal/src/graphics/kitty/animation.rs
@@ -1,0 +1,1125 @@
+//! Animation frame storage, composition, and control logic for the kitty graphics protocol.
+//!
+//! This module handles:
+//! - `a=f` (TransmitFrame): adding/editing animation frames
+//! - `a=a` (AnimationControl): controlling playback state
+//! - `a=c` (ComposeFrames): compositing pixels between frames
+//!
+//! Key design: **lazy promotion** — single-frame images stay as plain `KittyImage`.
+//! When a second frame arrives, the image is promoted to an `AnimationState`.
+//!
+//! See: <https://sw.kovidgoyal.net/kitty/graphics-protocol/#animation>
+
+use log::debug;
+
+use super::decode::decode_payload;
+use super::state::KittyState;
+use crate::graphics::kitty_parser::KittyCommand;
+use crate::graphics::ColorType;
+
+// ── Data Structures ────────────────────────────────────────────────────
+
+/// Composition mode for animation frames.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompositionMode {
+    /// Overwrite: new frame pixels replace old ones completely.
+    Overwrite,
+    /// AlphaBlend: composite new frame over old using standard alpha compositing.
+    AlphaBlend,
+}
+
+/// A single animation frame.
+#[derive(Debug, Clone)]
+pub struct AnimationFrame {
+    /// RGBA pixel data (always RGBA for animation).
+    pub pixels: Vec<u8>,
+    /// Frame width in pixels.
+    pub width: usize,
+    /// Frame height in pixels.
+    pub height: usize,
+    /// Frame duration in milliseconds (0 = use previous frame's duration).
+    pub gap_ms: u32,
+    /// How this frame composites over the previous.
+    pub composition_mode: CompositionMode,
+    /// Background color (RGBA packed as u32) to fill before compositing. 0 = transparent.
+    pub background: u32,
+}
+
+/// Playback state for an animated image.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlaybackState {
+    /// Animation is stopped.
+    Stopped,
+    /// Animation is running.
+    Running,
+    /// Animation is loading frames (not yet playing).
+    Loading,
+}
+
+/// Animation state for a multi-frame kitty image.
+#[derive(Debug)]
+pub struct AnimationState {
+    /// All frames in order.
+    pub frames: Vec<AnimationFrame>,
+    /// Currently displayed frame index.
+    pub current_frame: usize,
+    /// Playback state.
+    pub state: PlaybackState,
+    /// Number of loops (0 = infinite).
+    pub loops: u32,
+    /// Loops completed so far.
+    pub loops_done: u32,
+}
+
+impl AnimationState {
+    /// Create a new animation from a single frame.
+    pub fn new(first_frame: AnimationFrame) -> Self {
+        AnimationState {
+            frames: vec![first_frame],
+            current_frame: 0,
+            state: PlaybackState::Loading,
+            loops: 0,
+            loops_done: 0,
+        }
+    }
+
+    /// Add a new frame or edit an existing one.
+    ///
+    /// If `edit_index` is `Some(idx)` and `idx` is within bounds, replace that frame.
+    /// Otherwise, append the frame.
+    pub fn add_frame(&mut self, frame: AnimationFrame, edit_index: Option<usize>) {
+        match edit_index {
+            Some(idx) if idx < self.frames.len() => {
+                self.frames[idx] = frame;
+            },
+            _ => {
+                self.frames.push(frame);
+            },
+        }
+    }
+}
+
+// ── Core Pixel Composition ─────────────────────────────────────────────
+
+/// Core pixel composition function.
+///
+/// Composites `src` pixels over `dst` pixels for a frame of the given dimensions.
+/// Both `dst` and `src` are RGBA pixel data (4 bytes per pixel).
+///
+/// - If `background != 0`, fills `dst` with the background color first.
+/// - `Overwrite` mode: source pixels completely replace destination pixels.
+/// - `AlphaBlend` mode: standard "source over" alpha compositing.
+pub fn blit(
+    dst: &mut [u8],
+    src: &[u8],
+    width: usize,
+    height: usize,
+    mode: CompositionMode,
+    background: u32,
+) {
+    let frame_bytes = width * height * 4;
+    let dst_len = dst.len().min(frame_bytes);
+
+    // Fill with background color if specified.
+    if background != 0 {
+        let bg = background_to_rgba(background);
+        for pixel in dst[..dst_len].chunks_exact_mut(4) {
+            pixel.copy_from_slice(&bg);
+        }
+    }
+
+    let pixel_count = (dst_len / 4).min(src.len() / 4);
+
+    match mode {
+        CompositionMode::Overwrite => {
+            let byte_count = pixel_count * 4;
+            dst[..byte_count].copy_from_slice(&src[..byte_count]);
+        },
+        CompositionMode::AlphaBlend => {
+            for i in 0..pixel_count {
+                let off = i * 4;
+                alpha_blend_pixel(&mut dst[off..off + 4], &src[off..off + 4]);
+            }
+        },
+    }
+}
+
+/// Alpha-blend a single source pixel over a destination pixel (source-over compositing).
+///
+/// Both slices must be exactly 4 bytes (RGBA).
+///
+/// Formula (non-premultiplied):
+///   out_a = src_a + dst_a × (1 − src_a/255)
+///   out_c = (src_c × src_a + dst_c × dst_a × (1 − src_a/255)) / out_a
+fn alpha_blend_pixel(dst: &mut [u8], src: &[u8]) {
+    let sa = src[3] as u32;
+    if sa == 0 {
+        return; // Fully transparent source — no change.
+    }
+    if sa == 255 {
+        dst.copy_from_slice(src); // Fully opaque source — replace.
+        return;
+    }
+
+    let da = dst[3] as u32;
+    let inv_sa = 255 - sa;
+
+    // out_a = src_a + dst_a × (1 − src_a/255)
+    let out_a = sa + da * inv_sa / 255;
+
+    if out_a == 0 {
+        return;
+    }
+
+    for c in 0..3 {
+        let sc = src[c] as u32;
+        let dc = dst[c] as u32;
+        // out_c = (src_c × src_a + dst_c × dst_a × (1 − src_a/255)) / out_a
+        dst[c] = ((sc * sa + dc * da * inv_sa / 255) / out_a) as u8;
+    }
+    dst[3] = out_a as u8;
+}
+
+/// Unpack a u32 background color to RGBA bytes.
+///
+/// Byte order matches WezTerm: `0xRRGGBBAA`.
+fn background_to_rgba(bg: u32) -> [u8; 4] {
+    [
+        ((bg >> 24) & 0xff) as u8,
+        ((bg >> 16) & 0xff) as u8,
+        ((bg >> 8) & 0xff) as u8,
+        (bg & 0xff) as u8,
+    ]
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/// Ensure pixel data is RGBA (convert from RGB if needed).
+fn ensure_rgba(pixels: &[u8], color_type: ColorType) -> Vec<u8> {
+    match color_type {
+        ColorType::Rgba => pixels.to_vec(),
+        ColorType::Rgb => pixels
+            .chunks_exact(3)
+            .flat_map(|rgb| [rgb[0], rgb[1], rgb[2], 255])
+            .collect(),
+    }
+}
+
+/// Create a background-filled canvas of the given dimensions.
+fn make_background_canvas(width: usize, height: usize, background: u32) -> Vec<u8> {
+    let total = width * height * 4;
+    if background == 0 {
+        return vec![0u8; total];
+    }
+    let bg = background_to_rgba(background);
+    let mut canvas = vec![0u8; total];
+    for pixel in canvas.chunks_exact_mut(4) {
+        pixel.copy_from_slice(&bg);
+    }
+    canvas
+}
+
+/// Place source pixels onto a full-canvas-sized transparent buffer at position (x, y).
+fn place_on_canvas(
+    canvas_width: usize,
+    canvas_height: usize,
+    src: &[u8],
+    src_width: usize,
+    src_height: usize,
+    x: usize,
+    y: usize,
+) -> Vec<u8> {
+    let mut canvas = vec![0u8; canvas_width * canvas_height * 4];
+    for row in 0..src_height {
+        let dest_row = y + row;
+        if dest_row >= canvas_height {
+            break;
+        }
+        let copy_cols = src_width.min(canvas_width.saturating_sub(x));
+        if copy_cols == 0 {
+            continue;
+        }
+        let src_off = row * src_width * 4;
+        let dst_off = (dest_row * canvas_width + x) * 4;
+        let byte_count = copy_cols * 4;
+        if src_off + byte_count <= src.len() && dst_off + byte_count <= canvas.len() {
+            canvas[dst_off..dst_off + byte_count]
+                .copy_from_slice(&src[src_off..src_off + byte_count]);
+        }
+    }
+    canvas
+}
+
+// ── Action Handlers ────────────────────────────────────────────────────
+
+/// Handle `a=f` (TransmitFrame) — decode payload and add/edit an animation frame.
+///
+/// Follows the lazy promotion pattern: single-frame images stay as plain `KittyImage`
+/// until a second frame arrives, at which point an `AnimationState` is created.
+///
+/// Parser key overloading (action `f`):
+/// - `r=` → frame number to edit (1-based, 0 = append)
+/// - `z=` → frame duration in ms
+/// - `X=` → composition mode (0 = overwrite, 1 = alpha blend)
+/// - `Y=` → background pixel (RGBA packed u32)
+/// - `c=` → base frame to copy from (1-based)
+/// - `x=`, `y=` → blit position within the canvas
+pub fn load_animation_frame(
+    state: &mut KittyState,
+    cmd: &KittyCommand,
+    payload: &[u8],
+) -> Result<(), String> {
+    // Decode the transmitted pixel data.
+    let graphic_data = decode_payload(cmd, payload).map_err(|e| e.to_string())?;
+
+    let image_id = cmd.image_id;
+    if image_id == 0 {
+        return Err("image_id is required for animation frames".into());
+    }
+
+    // Read animation parameters from overloaded parser fields.
+    let frame_number = cmd.rows; // r= → frame to edit (1-based, 0 = append)
+    let gap_ms = cmd.z_index.max(0) as u32; // z= → frame duration in ms
+    let compose_mode = if cmd.offset_x == 1 {
+        CompositionMode::AlphaBlend
+    } else {
+        CompositionMode::Overwrite
+    };
+    let background = cmd.offset_y; // Y= → background pixel color
+    let base_frame = cmd.columns; // c= → base frame to copy from (1-based)
+    let dest_x = cmd.src_x as usize; // x= → blit x position
+    let dest_y = cmd.src_y as usize; // y= → blit y position
+
+    // Convert decoded data to RGBA.
+    let src_pixels = ensure_rgba(&graphic_data.pixels, graphic_data.color_type);
+    let src_width = graphic_data.width;
+    let src_height = graphic_data.height;
+
+    // Lazy promotion: if no animation exists yet, create one from the existing image.
+    if !state.animation_states.contains_key(&image_id) {
+        // Use direct field access to avoid borrowing all of `state` through a method.
+        let img = state
+            .images
+            .get(&image_id)
+            .ok_or_else(|| format!("image id={image_id} not found"))?;
+
+        let first_pixels = ensure_rgba(&img.data.pixels, img.data.color_type);
+        let first_frame = AnimationFrame {
+            width: img.data.width,
+            height: img.data.height,
+            pixels: first_pixels,
+            gap_ms: 0,
+            composition_mode: CompositionMode::Overwrite,
+            background: 0,
+        };
+
+        state
+            .animation_states
+            .insert(image_id, AnimationState::new(first_frame));
+        debug!("[kitty] promoted image id={image_id} to animation");
+    }
+
+    let anim = state.animation_states.get_mut(&image_id).unwrap();
+    let canvas_width = anim.frames[0].width;
+    let canvas_height = anim.frames[0].height;
+
+    // Determine whether to append or edit an existing frame (1-based → 0-based).
+    let edit_index = if frame_number > 0 && (frame_number as usize) <= anim.frames.len() {
+        Some(frame_number as usize - 1)
+    } else {
+        None // Append new frame.
+    };
+
+    // Build the canvas for this frame.
+    let mut canvas = if base_frame > 0 {
+        // Start from a copy of the base frame.
+        let base_idx = (base_frame as usize).saturating_sub(1);
+        if base_idx < anim.frames.len() {
+            anim.frames[base_idx].pixels.clone()
+        } else {
+            make_background_canvas(canvas_width, canvas_height, background)
+        }
+    } else if let Some(idx) = edit_index {
+        // Editing an existing frame — start from its current pixels.
+        anim.frames[idx].pixels.clone()
+    } else {
+        // New frame with background fill.
+        make_background_canvas(canvas_width, canvas_height, background)
+    };
+
+    // Blit the transmitted pixels onto the canvas.
+    if dest_x == 0 && dest_y == 0 && src_width == canvas_width && src_height == canvas_height {
+        // Fast path: full-frame blit (no positioning needed).
+        blit(&mut canvas, &src_pixels, canvas_width, canvas_height, compose_mode, 0);
+    } else {
+        // Place source pixels on a full-canvas transparent buffer, then blit.
+        let placed = place_on_canvas(
+            canvas_width,
+            canvas_height,
+            &src_pixels,
+            src_width,
+            src_height,
+            dest_x,
+            dest_y,
+        );
+        blit(&mut canvas, &placed, canvas_width, canvas_height, compose_mode, 0);
+    }
+
+    let new_frame = AnimationFrame {
+        pixels: canvas,
+        width: canvas_width,
+        height: canvas_height,
+        gap_ms,
+        composition_mode: compose_mode,
+        background,
+    };
+
+    anim.add_frame(new_frame, edit_index);
+    debug!(
+        "[kitty] animation id={image_id}: {} (total {} frames)",
+        if edit_index.is_some() { "edited frame" } else { "added frame" },
+        anim.frames.len()
+    );
+
+    Ok(())
+}
+
+/// Handle `a=c` (ComposeFrames) — copy pixel data between frames.
+///
+/// Copies (composites) pixel data from the source frame to the target frame
+/// within the same animation.
+///
+/// Parser key overloading (action `c`):
+/// - `c=` → source frame (1-based)
+/// - `r=` → target frame (1-based)
+/// - `X=` → composition mode (0 = overwrite, 1 = alpha blend)
+pub fn compose_frames(state: &mut KittyState, cmd: &KittyCommand) -> Result<(), String> {
+    let image_id = cmd.image_id;
+    if image_id == 0 {
+        return Err("image_id is required for compose".into());
+    }
+
+    // c= → source frame (1-based), r= → target frame (1-based).
+    let src_frame_no = cmd.columns as usize;
+    let target_frame_no = cmd.rows as usize;
+
+    if src_frame_no == 0 {
+        return Err("source frame must be > 0".into());
+    }
+    if target_frame_no == 0 {
+        return Err("target frame must be > 0".into());
+    }
+
+    let anim = state
+        .animation_states
+        .get_mut(&image_id)
+        .ok_or_else(|| format!("no animation for image id={image_id}"))?;
+
+    let src_idx = src_frame_no - 1;
+    let target_idx = target_frame_no - 1;
+
+    if src_idx >= anim.frames.len() {
+        return Err(format!(
+            "source frame {} out of range (have {} frames)",
+            src_frame_no,
+            anim.frames.len()
+        ));
+    }
+    if target_idx >= anim.frames.len() {
+        return Err(format!(
+            "target frame {} out of range (have {} frames)",
+            target_frame_no,
+            anim.frames.len()
+        ));
+    }
+
+    let compose_mode = if cmd.offset_x == 1 {
+        CompositionMode::AlphaBlend
+    } else {
+        CompositionMode::Overwrite
+    };
+
+    // Clone source pixels to avoid simultaneous mutable + immutable borrow.
+    let src_pixels = anim.frames[src_idx].pixels.clone();
+    let width = anim.frames[src_idx].width;
+    let height = anim.frames[src_idx].height;
+
+    blit(
+        &mut anim.frames[target_idx].pixels,
+        &src_pixels,
+        width,
+        height,
+        compose_mode,
+        0,
+    );
+
+    debug!(
+        "[kitty] composed frame {} → {} for image id={image_id}",
+        src_frame_no, target_frame_no
+    );
+
+    Ok(())
+}
+
+/// Handle `a=a` (AnimationControl) — control playback state, loops, and current frame.
+///
+/// Parser key overloading (action `a`):
+/// - `s=` (parsed as `cmd.width`) → animation state: 1=stop, 2=running, 3=loading
+/// - `v=` (parsed as `cmd.height`) → loop count (0 = infinite)
+/// - `r=` (parsed as `cmd.rows`) → set current frame (1-based)
+/// - `z=` (parsed as `cmd.z_index`) → set gap_ms for current frame
+pub fn control_animation(state: &mut KittyState, cmd: &KittyCommand) {
+    let image_id = cmd.image_id;
+    if image_id == 0 {
+        return;
+    }
+
+    let anim = match state.animation_states.get_mut(&image_id) {
+        Some(a) => a,
+        None => return,
+    };
+
+    // s= (parsed as cmd.width) → animation state.
+    match cmd.width {
+        1 => anim.state = PlaybackState::Stopped,
+        2 => anim.state = PlaybackState::Running,
+        3 => anim.state = PlaybackState::Loading,
+        _ => {},
+    }
+
+    // v= (parsed as cmd.height) → loop count (0 = infinite).
+    if cmd.height > 0 {
+        anim.loops = cmd.height;
+    }
+
+    // r= (parsed as cmd.rows) → set current frame (1-based).
+    if cmd.rows > 0 {
+        let idx = (cmd.rows as usize).saturating_sub(1);
+        if idx < anim.frames.len() {
+            anim.current_frame = idx;
+        }
+    }
+
+    // z= (parsed as cmd.z_index) → set gap_ms for current frame.
+    if cmd.z_index > 0 {
+        let current = anim.current_frame;
+        if current < anim.frames.len() {
+            anim.frames[current].gap_ms = cmd.z_index as u32;
+        }
+    }
+
+    debug!(
+        "[kitty] animation control id={image_id}: state={:?}, loops={}, current={}",
+        anim.state, anim.loops, anim.current_frame
+    );
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graphics::kitty_parser::{Action, Format, KittyCommand};
+    use crate::graphics::{ColorType, GraphicData, GraphicId};
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use base64::Engine;
+
+    /// Helper: create a simple animation frame with overwrite mode.
+    fn make_frame(pixels: Vec<u8>, width: usize, height: usize, gap_ms: u32) -> AnimationFrame {
+        AnimationFrame {
+            pixels,
+            width,
+            height,
+            gap_ms,
+            composition_mode: CompositionMode::Overwrite,
+            background: 0,
+        }
+    }
+
+    /// Helper: create a GraphicData for storing in KittyState.
+    fn make_graphic(pixels: Vec<u8>, width: usize, height: usize) -> GraphicData {
+        GraphicData {
+            id: GraphicId(0),
+            width,
+            height,
+            color_type: ColorType::Rgba,
+            pixels,
+            is_opaque: false,
+        }
+    }
+
+    // ── 1. Create AnimationState from a single frame ────────────────
+
+    #[test]
+    fn create_animation_state() {
+        let frame = make_frame(vec![255, 0, 0, 255], 1, 1, 100);
+        let anim = AnimationState::new(frame);
+
+        assert_eq!(anim.frames.len(), 1);
+        assert_eq!(anim.current_frame, 0);
+        assert_eq!(anim.state, PlaybackState::Loading);
+        assert_eq!(anim.loops, 0);
+        assert_eq!(anim.loops_done, 0);
+        assert_eq!(anim.frames[0].pixels, vec![255, 0, 0, 255]);
+        assert_eq!(anim.frames[0].gap_ms, 100);
+        assert_eq!(anim.frames[0].width, 1);
+        assert_eq!(anim.frames[0].height, 1);
+    }
+
+    // ── 2. Add frames, verify frame count and data ──────────────────
+
+    #[test]
+    fn add_frames_to_animation() {
+        let frame1 = make_frame(vec![255, 0, 0, 255], 1, 1, 100);
+        let mut anim = AnimationState::new(frame1);
+
+        let frame2 = make_frame(vec![0, 255, 0, 255], 1, 1, 200);
+        anim.add_frame(frame2, None);
+
+        let frame3 = make_frame(vec![0, 0, 255, 255], 1, 1, 150);
+        anim.add_frame(frame3, None);
+
+        assert_eq!(anim.frames.len(), 3);
+        assert_eq!(anim.frames[0].pixels, vec![255, 0, 0, 255]);
+        assert_eq!(anim.frames[1].pixels, vec![0, 255, 0, 255]);
+        assert_eq!(anim.frames[2].pixels, vec![0, 0, 255, 255]);
+        assert_eq!(anim.frames[0].gap_ms, 100);
+        assert_eq!(anim.frames[1].gap_ms, 200);
+        assert_eq!(anim.frames[2].gap_ms, 150);
+    }
+
+    // ── 3. Edit an existing frame by index ──────────────────────────
+
+    #[test]
+    fn edit_frame_by_index() {
+        let frame1 = make_frame(vec![255, 0, 0, 255], 1, 1, 100);
+        let mut anim = AnimationState::new(frame1);
+
+        let frame2 = make_frame(vec![0, 255, 0, 255], 1, 1, 200);
+        anim.add_frame(frame2, None);
+
+        // Edit frame 0: replace red with blue.
+        let edit = make_frame(vec![0, 0, 255, 255], 1, 1, 300);
+        anim.add_frame(edit, Some(0));
+
+        assert_eq!(anim.frames.len(), 2); // Still 2 frames.
+        assert_eq!(anim.frames[0].pixels, vec![0, 0, 255, 255]); // Replaced.
+        assert_eq!(anim.frames[0].gap_ms, 300);
+        assert_eq!(anim.frames[1].pixels, vec![0, 255, 0, 255]); // Unchanged.
+    }
+
+    #[test]
+    fn edit_frame_out_of_bounds_appends() {
+        let frame1 = make_frame(vec![255, 0, 0, 255], 1, 1, 100);
+        let mut anim = AnimationState::new(frame1);
+
+        // Index 5 is out of bounds — should append instead.
+        let frame_new = make_frame(vec![0, 255, 0, 255], 1, 1, 50);
+        anim.add_frame(frame_new, Some(5));
+
+        assert_eq!(anim.frames.len(), 2);
+        assert_eq!(anim.frames[1].pixels, vec![0, 255, 0, 255]);
+    }
+
+    // ── 4. blit in Overwrite mode ───────────────────────────────────
+
+    #[test]
+    fn blit_overwrite_mode() {
+        // 2-pixel destination: red, green.
+        let mut dst = vec![255, 0, 0, 255, 0, 255, 0, 255];
+        // 2-pixel source: blue, white.
+        let src = vec![0, 0, 255, 255, 255, 255, 255, 255];
+
+        blit(&mut dst, &src, 2, 1, CompositionMode::Overwrite, 0);
+
+        // Source completely overwrites destination.
+        assert_eq!(dst, vec![0, 0, 255, 255, 255, 255, 255, 255]);
+    }
+
+    #[test]
+    fn blit_overwrite_replaces_even_transparent() {
+        let mut dst = vec![255, 0, 0, 255]; // Opaque red.
+        let src = vec![0, 0, 0, 0]; // Fully transparent.
+
+        blit(&mut dst, &src, 1, 1, CompositionMode::Overwrite, 0);
+
+        // Overwrite replaces dst with transparent.
+        assert_eq!(dst, vec![0, 0, 0, 0]);
+    }
+
+    // ── 5. blit in AlphaBlend mode ──────────────────────────────────
+
+    #[test]
+    fn blit_alpha_blend_50_percent() {
+        // Opaque black destination.
+        let mut dst = vec![0, 0, 0, 255];
+        // 50% alpha white source (alpha = 128).
+        let src = vec![255, 255, 255, 128];
+
+        blit(&mut dst, &src, 1, 1, CompositionMode::AlphaBlend, 0);
+
+        // sa=128, da=255, inv_sa=127
+        // out_a = 128 + 255*127/255 = 128 + 127 = 255
+        // out_r = (255*128 + 0*255*127/255) / 255 = 32640/255 = 128
+        assert_eq!(dst[0], 128); // R
+        assert_eq!(dst[1], 128); // G
+        assert_eq!(dst[2], 128); // B
+        assert_eq!(dst[3], 255); // A
+    }
+
+    #[test]
+    fn blit_alpha_blend_transparent_source_unchanged() {
+        let mut dst = vec![255, 0, 0, 255]; // Opaque red.
+        let src = vec![0, 255, 0, 0]; // Fully transparent green.
+
+        blit(&mut dst, &src, 1, 1, CompositionMode::AlphaBlend, 0);
+
+        // Transparent source should not change destination.
+        assert_eq!(dst, vec![255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn blit_alpha_blend_opaque_source_replaces() {
+        let mut dst = vec![255, 0, 0, 255]; // Opaque red.
+        let src = vec![0, 255, 0, 255]; // Opaque green.
+
+        blit(&mut dst, &src, 1, 1, CompositionMode::AlphaBlend, 0);
+
+        // Opaque source should fully replace destination.
+        assert_eq!(dst, vec![0, 255, 0, 255]);
+    }
+
+    #[test]
+    fn blit_alpha_blend_onto_transparent_dst() {
+        let mut dst = vec![0, 0, 0, 0]; // Fully transparent.
+        let src = vec![200, 100, 50, 128]; // 50% alpha.
+
+        blit(&mut dst, &src, 1, 1, CompositionMode::AlphaBlend, 0);
+
+        // Source over transparent: out_a = 128 + 0*127/255 = 128
+        // out_c = (sc * 128 + 0) / 128 = sc
+        assert_eq!(dst[0], 200);
+        assert_eq!(dst[1], 100);
+        assert_eq!(dst[2], 50);
+        assert_eq!(dst[3], 128);
+    }
+
+    // ── 6. Background fill before blit ──────────────────────────────
+
+    #[test]
+    fn blit_background_fill_then_alpha_blend() {
+        let mut dst = vec![0, 0, 0, 0]; // Transparent.
+        let src = vec![0, 0, 0, 0]; // Transparent source.
+        // Red background with full alpha: R=0xFF, G=0x00, B=0x00, A=0xFF → 0xFF0000FF.
+        let background: u32 = 0xFF_00_00_FF;
+
+        blit(&mut dst, &src, 1, 1, CompositionMode::AlphaBlend, background);
+
+        // Background fills first, then transparent source is blended (no change).
+        assert_eq!(dst, vec![255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn blit_background_fill_then_overwrite() {
+        let mut dst = vec![0, 0, 0, 0]; // Transparent.
+        let src = vec![0, 0, 255, 255]; // Opaque blue.
+        // Green background: 0x00FF00FF.
+        let background: u32 = 0x00_FF_00_FF;
+
+        blit(&mut dst, &src, 1, 1, CompositionMode::Overwrite, background);
+
+        // Background fills first, then overwrite replaces with blue.
+        assert_eq!(dst, vec![0, 0, 255, 255]);
+    }
+
+    #[test]
+    fn blit_background_fill_visible_with_partial_alpha_src() {
+        let mut dst = vec![0, 0, 0, 0];
+        // 50% alpha green source.
+        let src = vec![0, 255, 0, 128];
+        // Opaque red background: 0xFF0000FF.
+        let background: u32 = 0xFF_00_00_FF;
+
+        blit(&mut dst, &src, 1, 1, CompositionMode::AlphaBlend, background);
+
+        // dst is filled with red first, then green at 50% is blended over.
+        // sa=128, da=255, inv_sa=127
+        // out_a = 128 + 255*127/255 = 255
+        // R: (0*128 + 255*255*127/255) / 255 = (0 + 32385) / 255 = 127
+        // G: (255*128 + 0*255*127/255) / 255 = 32640/255 = 128
+        // B: (0*128 + 0*255*127/255) / 255 = 0
+        assert_eq!(dst[0], 127); // R (background red bleeds through)
+        assert_eq!(dst[1], 128); // G (source green)
+        assert_eq!(dst[2], 0); // B
+        assert_eq!(dst[3], 255); // A
+    }
+
+    // ── 7. control_animation: start, stop, set loops ────────────────
+
+    #[test]
+    fn control_animation_start_stop_loading() {
+        let mut state = KittyState::default();
+        let frame = make_frame(vec![0; 4], 1, 1, 100);
+        state.animation_states.insert(1, AnimationState::new(frame));
+
+        // Start (s=2 → Running).
+        control_animation(
+            &mut state,
+            &KittyCommand { image_id: 1, width: 2, ..Default::default() },
+        );
+        assert_eq!(state.get_animation(1).unwrap().state, PlaybackState::Running);
+
+        // Stop (s=1 → Stopped).
+        control_animation(
+            &mut state,
+            &KittyCommand { image_id: 1, width: 1, ..Default::default() },
+        );
+        assert_eq!(state.get_animation(1).unwrap().state, PlaybackState::Stopped);
+
+        // Loading (s=3 → Loading).
+        control_animation(
+            &mut state,
+            &KittyCommand { image_id: 1, width: 3, ..Default::default() },
+        );
+        assert_eq!(state.get_animation(1).unwrap().state, PlaybackState::Loading);
+    }
+
+    #[test]
+    fn control_animation_set_loops() {
+        let mut state = KittyState::default();
+        let frame = make_frame(vec![0; 4], 1, 1, 100);
+        state.animation_states.insert(1, AnimationState::new(frame));
+
+        // Set loops to 5 (v=5, parsed as cmd.height).
+        control_animation(
+            &mut state,
+            &KittyCommand { image_id: 1, height: 5, ..Default::default() },
+        );
+        assert_eq!(state.get_animation(1).unwrap().loops, 5);
+    }
+
+    #[test]
+    fn control_animation_set_current_frame() {
+        let mut state = KittyState::default();
+        let frame1 = make_frame(vec![0; 4], 1, 1, 100);
+        let frame2 = make_frame(vec![0; 4], 1, 1, 100);
+        let mut anim = AnimationState::new(frame1);
+        anim.add_frame(frame2, None);
+        state.animation_states.insert(1, anim);
+
+        // Set current frame to 2 (r=2, parsed as cmd.rows, 1-based).
+        control_animation(
+            &mut state,
+            &KittyCommand { image_id: 1, rows: 2, ..Default::default() },
+        );
+        assert_eq!(state.get_animation(1).unwrap().current_frame, 1); // 0-based.
+    }
+
+    #[test]
+    fn control_animation_set_gap_for_current_frame() {
+        let mut state = KittyState::default();
+        let frame = make_frame(vec![0; 4], 1, 1, 100);
+        state.animation_states.insert(1, AnimationState::new(frame));
+
+        // Set gap_ms to 50 for current frame (z=50, parsed as cmd.z_index).
+        control_animation(
+            &mut state,
+            &KittyCommand { image_id: 1, z_index: 50, ..Default::default() },
+        );
+        assert_eq!(state.get_animation(1).unwrap().frames[0].gap_ms, 50);
+    }
+
+    #[test]
+    fn control_animation_noop_for_missing_image() {
+        let mut state = KittyState::default();
+        // Should not panic or error for a non-existent image.
+        control_animation(
+            &mut state,
+            &KittyCommand { image_id: 999, width: 2, ..Default::default() },
+        );
+    }
+
+    // ── 8. Frame promotion: KittyImage → AnimationState ─────────────
+
+    #[test]
+    fn frame_promotion_on_second_frame() {
+        let mut state = KittyState::default();
+
+        // Store a 2×1 RGBA image (red + green pixels).
+        let original = make_graphic(
+            vec![255, 0, 0, 255, 0, 255, 0, 255],
+            2,
+            1,
+        );
+        state.store_image(1, original);
+
+        // No animation yet.
+        assert!(state.get_animation(1).is_none());
+
+        // Transmit a second frame (2×1: blue + white).
+        let frame_pixels: Vec<u8> = vec![0, 0, 255, 255, 255, 255, 255, 255];
+        let encoded = BASE64.encode(&frame_pixels);
+        let cmd = KittyCommand {
+            action: Action::TransmitFrame,
+            format: Format::Rgba,
+            width: 2,
+            height: 1,
+            image_id: 1,
+            payload: encoded.into_bytes(),
+            ..Default::default()
+        };
+
+        let result = load_animation_frame(&mut state, &cmd, &cmd.payload);
+        assert!(result.is_ok(), "load_animation_frame failed: {result:?}");
+
+        // Verify promotion to animation.
+        let anim = state.get_animation(1).expect("animation should exist");
+        assert_eq!(anim.frames.len(), 2);
+
+        // Frame 0 = original image data.
+        assert_eq!(anim.frames[0].pixels, vec![255, 0, 0, 255, 0, 255, 0, 255]);
+        assert_eq!(anim.frames[0].width, 2);
+        assert_eq!(anim.frames[0].height, 1);
+
+        // Frame 1 = new frame data (blitted in overwrite mode onto transparent canvas).
+        assert_eq!(anim.frames[1].pixels, vec![0, 0, 255, 255, 255, 255, 255, 255]);
+    }
+
+    #[test]
+    fn frame_promotion_preserves_rgb_as_rgba() {
+        let mut state = KittyState::default();
+
+        // Store a 1×1 RGB image (no alpha channel).
+        let original = GraphicData {
+            id: GraphicId(0),
+            width: 1,
+            height: 1,
+            color_type: ColorType::Rgb,
+            pixels: vec![128, 64, 32],
+            is_opaque: true,
+        };
+        state.store_image(2, original);
+
+        // Transmit a second frame in RGBA.
+        let frame_pixels: Vec<u8> = vec![0, 0, 0, 255];
+        let encoded = BASE64.encode(&frame_pixels);
+        let cmd = KittyCommand {
+            action: Action::TransmitFrame,
+            format: Format::Rgba,
+            width: 1,
+            height: 1,
+            image_id: 2,
+            payload: encoded.into_bytes(),
+            ..Default::default()
+        };
+
+        let result = load_animation_frame(&mut state, &cmd, &cmd.payload);
+        assert!(result.is_ok());
+
+        let anim = state.get_animation(2).unwrap();
+        assert_eq!(anim.frames.len(), 2);
+        // Frame 0: RGB promoted to RGBA with alpha=255.
+        assert_eq!(anim.frames[0].pixels, vec![128, 64, 32, 255]);
+    }
+
+    #[test]
+    fn frame_edit_existing_via_frame_number() {
+        let mut state = KittyState::default();
+
+        // Store a 1×1 image and promote to animation.
+        state.store_image(1, make_graphic(vec![255, 0, 0, 255], 1, 1));
+
+        // Add a second frame to create animation.
+        let frame2 = vec![0, 255, 0, 255];
+        let encoded2 = BASE64.encode(&frame2);
+        let cmd2 = KittyCommand {
+            action: Action::TransmitFrame,
+            format: Format::Rgba,
+            width: 1,
+            height: 1,
+            image_id: 1,
+            payload: encoded2.into_bytes(),
+            ..Default::default()
+        };
+        load_animation_frame(&mut state, &cmd2, &cmd2.payload).unwrap();
+        assert_eq!(state.get_animation(1).unwrap().frames.len(), 2);
+
+        // Edit frame 1 (1-based) with blue.
+        let edit_pixels = vec![0, 0, 255, 255];
+        let encoded_edit = BASE64.encode(&edit_pixels);
+        let cmd_edit = KittyCommand {
+            action: Action::TransmitFrame,
+            format: Format::Rgba,
+            width: 1,
+            height: 1,
+            image_id: 1,
+            rows: 1, // r=1 → edit frame index 1 (1-based).
+            payload: encoded_edit.into_bytes(),
+            ..Default::default()
+        };
+
+        load_animation_frame(&mut state, &cmd_edit, &cmd_edit.payload).unwrap();
+
+        let anim = state.get_animation(1).unwrap();
+        assert_eq!(anim.frames.len(), 2); // Still 2 frames.
+        // Frame 0 was edited: now blue instead of red.
+        assert_eq!(anim.frames[0].pixels, vec![0, 0, 255, 255]);
+        // Frame 1 unchanged.
+        assert_eq!(anim.frames[1].pixels, vec![0, 255, 0, 255]);
+    }
+
+    #[test]
+    fn load_animation_frame_missing_image() {
+        let mut state = KittyState::default();
+
+        let frame_pixels = vec![0, 0, 0, 255];
+        let encoded = BASE64.encode(&frame_pixels);
+        let cmd = KittyCommand {
+            action: Action::TransmitFrame,
+            format: Format::Rgba,
+            width: 1,
+            height: 1,
+            image_id: 999, // Non-existent.
+            payload: encoded.into_bytes(),
+            ..Default::default()
+        };
+
+        let result = load_animation_frame(&mut state, &cmd, &cmd.payload);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not found"));
+    }
+
+    // ── 9. compose_frames: copy pixels between frames ───────────────
+
+    #[test]
+    fn compose_frames_copies_pixels() {
+        let mut state = KittyState::default();
+
+        // Create animation with 2 frames: red+green, and all-transparent.
+        let frame1 = make_frame(vec![255, 0, 0, 255, 0, 255, 0, 255], 2, 1, 100);
+        let frame2 = make_frame(vec![0, 0, 0, 0, 0, 0, 0, 0], 2, 1, 100);
+        let mut anim = AnimationState::new(frame1);
+        anim.add_frame(frame2, None);
+        state.animation_states.insert(1, anim);
+
+        // Compose: copy frame 1 → frame 2 (overwrite mode).
+        let cmd = KittyCommand {
+            image_id: 1,
+            columns: 1, // c= source frame (1-based).
+            rows: 2,    // r= target frame (1-based).
+            ..Default::default()
+        };
+
+        let result = compose_frames(&mut state, &cmd);
+        assert!(result.is_ok());
+
+        let anim = state.get_animation(1).unwrap();
+        // Target frame should now have source frame's pixels.
+        assert_eq!(anim.frames[1].pixels, vec![255, 0, 0, 255, 0, 255, 0, 255]);
+        // Source frame unchanged.
+        assert_eq!(anim.frames[0].pixels, vec![255, 0, 0, 255, 0, 255, 0, 255]);
+    }
+
+    #[test]
+    fn compose_frames_alpha_blend() {
+        let mut state = KittyState::default();
+
+        // Frame 1: opaque black.
+        let frame1 = make_frame(vec![0, 0, 0, 255], 1, 1, 100);
+        // Frame 2: 50% white.
+        let frame2 = make_frame(vec![255, 255, 255, 128], 1, 1, 100);
+        let mut anim = AnimationState::new(frame1);
+        anim.add_frame(frame2, None);
+        state.animation_states.insert(1, anim);
+
+        // Compose frame 2 → frame 1 with alpha blend.
+        let cmd = KittyCommand {
+            image_id: 1,
+            columns: 2,   // c= source (50% white).
+            rows: 1,       // r= target (opaque black).
+            offset_x: 1,  // X=1 → alpha blend.
+            ..Default::default()
+        };
+
+        compose_frames(&mut state, &cmd).unwrap();
+
+        let anim = state.get_animation(1).unwrap();
+        // 50% white over opaque black: expect ~128 gray.
+        assert_eq!(anim.frames[0].pixels[0], 128); // R
+        assert_eq!(anim.frames[0].pixels[1], 128); // G
+        assert_eq!(anim.frames[0].pixels[2], 128); // B
+        assert_eq!(anim.frames[0].pixels[3], 255); // A
+    }
+
+    #[test]
+    fn compose_frames_invalid_source() {
+        let mut state = KittyState::default();
+        let frame = make_frame(vec![0; 4], 1, 1, 100);
+        state.animation_states.insert(1, AnimationState::new(frame));
+
+        let cmd = KittyCommand {
+            image_id: 1,
+            columns: 5, // Source frame 5 doesn't exist.
+            rows: 1,
+            ..Default::default()
+        };
+
+        let result = compose_frames(&mut state, &cmd);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("out of range"));
+    }
+
+    #[test]
+    fn compose_frames_no_animation() {
+        let mut state = KittyState::default();
+
+        let cmd = KittyCommand {
+            image_id: 42,
+            columns: 1,
+            rows: 1,
+            ..Default::default()
+        };
+
+        let result = compose_frames(&mut state, &cmd);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("no animation"));
+    }
+
+    // ── Helpers / edge cases ────────────────────────────────────────
+
+    #[test]
+    fn background_to_rgba_unpacks_correctly() {
+        let bg = background_to_rgba(0xFF_80_40_C0);
+        assert_eq!(bg, [0xFF, 0x80, 0x40, 0xC0]);
+    }
+
+    #[test]
+    fn ensure_rgba_passthrough() {
+        let rgba = vec![1, 2, 3, 4, 5, 6, 7, 8];
+        let result = ensure_rgba(&rgba, ColorType::Rgba);
+        assert_eq!(result, rgba);
+    }
+
+    #[test]
+    fn ensure_rgba_from_rgb() {
+        let rgb = vec![10, 20, 30, 40, 50, 60];
+        let result = ensure_rgba(&rgb, ColorType::Rgb);
+        assert_eq!(result, vec![10, 20, 30, 255, 40, 50, 60, 255]);
+    }
+
+    #[test]
+    fn place_on_canvas_with_offset() {
+        // 3×2 canvas, place a 1×1 pixel at (1, 1).
+        let src = vec![255, 0, 0, 255]; // Single red pixel.
+        let canvas = place_on_canvas(3, 2, &src, 1, 1, 1, 1);
+
+        // Expected: 3×2 canvas, all transparent except (1,1) which is red.
+        assert_eq!(canvas.len(), 3 * 2 * 4); // 24 bytes.
+        // Row 0: 3 transparent pixels.
+        assert_eq!(&canvas[0..12], &[0; 12]);
+        // Row 1: transparent, red, transparent.
+        assert_eq!(&canvas[12..16], &[0, 0, 0, 0]); // (0,1)
+        assert_eq!(&canvas[16..20], &[255, 0, 0, 255]); // (1,1)
+        assert_eq!(&canvas[20..24], &[0, 0, 0, 0]); // (2,1)
+    }
+}

--- a/alacritty_terminal/src/graphics/kitty/decode.rs
+++ b/alacritty_terminal/src/graphics/kitty/decode.rs
@@ -1,11 +1,28 @@
 //! Kitty graphics payload decode pipeline.
 //!
 //! Pipeline: base64 → zlib (optional) → format decode → GraphicData
+//!
+//! Supported transmission mediums:
+//! - `Direct` (`t=d`): inline base64 payload
+//! - `File` (`t=f`): base64-encoded file path
+//! - `TempFile` (`t=t`): base64-encoded path relative to temp dir
+//! - `SharedMemory` (`t=s`): base64-encoded POSIX shm object name (unix only)
 
 use std::io::Read;
 
 use base64::Engine;
-use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::alphabet;
+use base64::engine::{GeneralPurpose, GeneralPurposeConfig, DecodePaddingMode};
+
+/// Lenient base64 decoder: accepts both padded and unpadded input.
+///
+/// Chunked kitty transfers concatenate base64 across multiple APC sequences.
+/// Some clients (e.g. chafa) pad each chunk with `=`, so the merged payload
+/// can have `=` in the middle. Stripping padding before decode handles this.
+const BASE64: GeneralPurpose = GeneralPurpose::new(
+    &alphabet::STANDARD,
+    GeneralPurposeConfig::new().with_decode_padding_mode(DecodePaddingMode::Indifferent),
+);
 use flate2::read::ZlibDecoder;
 
 use crate::graphics::kitty_parser::{Compression, Format, KittyCommand, Medium};
@@ -24,6 +41,8 @@ pub enum DecodeError {
     InvalidDimensions(String),
     UnsupportedMedium(Medium),
     MissingDimensions,
+    IoError(String),
+    PathTraversal(String),
 }
 
 impl std::fmt::Display for DecodeError {
@@ -35,30 +54,249 @@ impl std::fmt::Display for DecodeError {
             DecodeError::InvalidDimensions(e) => write!(f, "invalid dimensions: {e}"),
             DecodeError::UnsupportedMedium(m) => write!(f, "unsupported medium: {m:?}"),
             DecodeError::MissingDimensions => write!(f, "missing width/height for raw format"),
+            DecodeError::IoError(e) => write!(f, "I/O error: {e}"),
+            DecodeError::PathTraversal(e) => write!(f, "path traversal rejected: {e}"),
         }
     }
 }
 
 /// Decode a kitty graphics payload into a `GraphicData`.
 ///
-/// Pipeline: base64 → zlib (optional) → format decode → GraphicData
+/// Pipeline: medium-specific read → zlib (optional) → format decode → GraphicData
+///
+/// When `cmd.pre_decoded` is true (set by chunked transfer finalization),
+/// the payload already contains raw decoded bytes — base64 is skipped.
+/// This handles clients like chafa that independently base64-encode each
+/// chunk, which would corrupt group alignment if concatenated as strings.
 pub fn decode_payload(cmd: &KittyCommand, raw_payload: &[u8]) -> Result<GraphicData, DecodeError> {
-    if cmd.medium != Medium::Direct {
-        return Err(DecodeError::UnsupportedMedium(cmd.medium));
-    }
+    let raw_bytes = if cmd.pre_decoded {
+        // Chunked transfer already decoded each chunk's base64 on arrival.
+        raw_payload.to_vec()
+    } else {
+        match cmd.medium {
+            Medium::Direct => decode_direct_payload(raw_payload)?,
+            Medium::File => read_file_payload(raw_payload, cmd.data_offset, cmd.data_size, false)?,
+            Medium::TempFile => read_file_payload(raw_payload, cmd.data_offset, cmd.data_size, true)?,
+            #[cfg(unix)]
+            Medium::SharedMemory => read_shm_payload(raw_payload, cmd.data_offset, cmd.data_size)?,
+            #[cfg(not(unix))]
+            Medium::SharedMemory => return Err(DecodeError::UnsupportedMedium(cmd.medium)),
+        }
+    };
 
-    let decoded = BASE64
+    decode_raw_bytes(cmd, raw_bytes)
+}
+
+/// Decode an inline base64 payload (Medium::Direct).
+///
+/// Strips `=` padding before decoding to handle chunked transfers where
+/// intermediate chunks include trailing padding characters.
+fn decode_direct_payload(raw_payload: &[u8]) -> Result<Vec<u8>, DecodeError> {
+    let cleaned: Vec<u8> = raw_payload.iter().copied().filter(|&b| b != b'=').collect();
+    BASE64
+        .decode(&cleaned)
+        .map_err(|e| DecodeError::Base64(e.to_string()))
+}
+
+/// Read payload from a file path (Medium::File or Medium::TempFile).
+///
+/// The `raw_payload` is a base64-encoded filesystem path. For TempFile,
+/// the decoded path is joined relative to `std::env::temp_dir()` and must
+/// not contain `..` components or escape the temp directory.
+fn read_file_payload(
+    raw_payload: &[u8],
+    data_offset: u32,
+    data_size: u32,
+    is_temp: bool,
+) -> Result<Vec<u8>, DecodeError> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let path_bytes = BASE64
         .decode(raw_payload)
         .map_err(|e| DecodeError::Base64(e.to_string()))?;
+    let path_str = String::from_utf8(path_bytes)
+        .map_err(|e| DecodeError::IoError(format!("invalid UTF-8 in path: {e}")))?;
 
+    let resolved_path = if is_temp {
+        validate_temp_path(&path_str)?;
+        let temp_dir = std::env::temp_dir();
+        temp_dir.join(&path_str)
+    } else {
+        std::path::PathBuf::from(&path_str)
+    };
+
+    let mut file = std::fs::File::open(&resolved_path)
+        .map_err(|e| DecodeError::IoError(format!("open {:?}: {e}", resolved_path)))?;
+
+    if data_offset > 0 {
+        file.seek(SeekFrom::Start(u64::from(data_offset)))
+            .map_err(|e| DecodeError::IoError(format!("seek: {e}")))?;
+    }
+
+    let data = if data_size > 0 {
+        let mut buf = vec![0u8; data_size as usize];
+        file.read_exact(&mut buf)
+            .map_err(|e| DecodeError::IoError(format!("read_exact: {e}")))?;
+        buf
+    } else {
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf)
+            .map_err(|e| DecodeError::IoError(format!("read_to_end: {e}")))?;
+        buf
+    };
+
+    // For temp files, delete after reading (kitty/wezterm behavior).
+    if is_temp {
+        if let Err(e) = std::fs::remove_file(&resolved_path) {
+            log::warn!(
+                "[kitty] failed to remove temp file {:?}: {e}",
+                resolved_path
+            );
+        }
+    }
+
+    Ok(data)
+}
+
+/// Validate that a temp-file relative path does not escape the temp directory.
+///
+/// Rejects paths containing `..` components, absolute paths, and any other
+/// attempt to traverse outside the temp dir.
+fn validate_temp_path(path: &str) -> Result<(), DecodeError> {
+    use std::path::Component;
+
+    let path_obj = std::path::Path::new(path);
+
+    // Reject absolute paths — temp file paths must be relative.
+    if path_obj.is_absolute() {
+        return Err(DecodeError::PathTraversal(format!(
+            "absolute path not allowed for temp file: {path}"
+        )));
+    }
+
+    for component in path_obj.components() {
+        match component {
+            Component::ParentDir => {
+                return Err(DecodeError::PathTraversal(format!(
+                    "path contains '..': {path}"
+                )));
+            },
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(DecodeError::PathTraversal(format!(
+                    "path escapes temp directory: {path}"
+                )));
+            },
+            Component::CurDir | Component::Normal(_) => {},
+        }
+    }
+
+    Ok(())
+}
+
+/// Read payload from a POSIX shared memory object (Medium::SharedMemory).
+///
+/// Opens the named shm object via `shm_open`, determines its size with
+/// `fstat`, maps it with `mmap`, copies the requested range, then cleans
+/// up with `munmap`, `close`, and `shm_unlink`.
+///
+/// We use `mmap` rather than `read(2)` because macOS shm file descriptors
+/// do not support regular file I/O (seek / read return ENODEV).
+#[cfg(unix)]
+fn read_shm_payload(
+    raw_payload: &[u8],
+    data_offset: u32,
+    data_size: u32,
+) -> Result<Vec<u8>, DecodeError> {
+    use std::ffi::CString;
+
+    let name_bytes = BASE64
+        .decode(raw_payload)
+        .map_err(|e| DecodeError::Base64(e.to_string()))?;
+    let name_str = String::from_utf8(name_bytes)
+        .map_err(|e| DecodeError::IoError(format!("invalid UTF-8 in shm name: {e}")))?;
+
+    let c_name = CString::new(name_str.as_bytes())
+        .map_err(|e| DecodeError::IoError(format!("invalid shm name: {e}")))?;
+
+    // Open the shared memory object (read-only).
+    let fd = unsafe { libc::shm_open(c_name.as_ptr(), libc::O_RDONLY, 0) };
+    if fd < 0 {
+        let err = std::io::Error::last_os_error();
+        return Err(DecodeError::IoError(format!("shm_open '{}': {err}", name_str)));
+    }
+
+    // Determine total size of the shm object via fstat.
+    let total_size = unsafe {
+        let mut stat: libc::stat = std::mem::zeroed();
+        if libc::fstat(fd, &mut stat) != 0 {
+            let err = std::io::Error::last_os_error();
+            libc::close(fd);
+            return Err(DecodeError::IoError(format!("fstat shm '{}': {err}", name_str)));
+        }
+        stat.st_size as usize
+    };
+
+    if total_size == 0 {
+        unsafe {
+            libc::close(fd);
+            libc::shm_unlink(c_name.as_ptr());
+        }
+        return Err(DecodeError::IoError(format!("shm '{}' has zero size", name_str)));
+    }
+
+    // mmap the entire object read-only.
+    let ptr = unsafe {
+        libc::mmap(std::ptr::null_mut(), total_size, libc::PROT_READ, libc::MAP_SHARED, fd, 0)
+    };
+
+    // Close the fd immediately — the mapping keeps the memory accessible.
+    unsafe { libc::close(fd) };
+
+    if ptr == libc::MAP_FAILED {
+        let err = std::io::Error::last_os_error();
+        unsafe { libc::shm_unlink(c_name.as_ptr()) };
+        return Err(DecodeError::IoError(format!("mmap shm '{}': {err}", name_str)));
+    }
+
+    // Compute the slice we need to copy.
+    let offset = data_offset as usize;
+    let len = if data_size > 0 { data_size as usize } else { total_size.saturating_sub(offset) };
+
+    let result = if offset + len > total_size {
+        Err(DecodeError::IoError(format!(
+            "shm '{}': offset({offset}) + size({len}) exceeds total({total_size})",
+            name_str
+        )))
+    } else {
+        let src = unsafe { std::slice::from_raw_parts((ptr as *const u8).add(offset), len) };
+        Ok(src.to_vec())
+    };
+
+    // Unmap + unlink regardless of whether the copy succeeded.
+    unsafe {
+        libc::munmap(ptr, total_size);
+    }
+    let ret = unsafe { libc::shm_unlink(c_name.as_ptr()) };
+    if ret < 0 {
+        let err = std::io::Error::last_os_error();
+        log::warn!("[kitty] shm_unlink '{}': {err}", name_str);
+    }
+
+    result
+}
+
+/// Shared decode tail: decompress (optional zlib) then format-decode.
+fn decode_raw_bytes(cmd: &KittyCommand, raw: Vec<u8>) -> Result<GraphicData, DecodeError> {
     let decompressed = match cmd.compression {
         Compression::Zlib => {
-            let mut decoder = ZlibDecoder::new(&decoded[..]);
+            let mut decoder = ZlibDecoder::new(&raw[..]);
             let mut buf = Vec::new();
-            decoder.read_to_end(&mut buf).map_err(|e| DecodeError::Zlib(e.to_string()))?;
+            decoder
+                .read_to_end(&mut buf)
+                .map_err(|e| DecodeError::Zlib(e.to_string()))?;
             buf
         },
-        Compression::None => decoded,
+        Compression::None => raw,
     };
 
     match cmd.format {
@@ -69,7 +307,7 @@ pub fn decode_payload(cmd: &KittyCommand, raw_payload: &[u8]) -> Result<GraphicD
 }
 
 fn decode_png(data: &[u8]) -> Result<GraphicData, DecodeError> {
-    let decoder = png::Decoder::new(data);
+    let decoder = png::Decoder::new(std::io::Cursor::new(data));
     let mut reader = decoder.read_info().map_err(|e| DecodeError::Png(e.to_string()))?;
 
     let info = reader.info();
@@ -88,7 +326,8 @@ fn decode_png(data: &[u8]) -> Result<GraphicData, DecodeError> {
         )));
     }
 
-    let mut buf = vec![0u8; reader.output_buffer_size()];
+    let buf_size = reader.output_buffer_size().unwrap_or(width * height * 4);
+    let mut buf = vec![0u8; buf_size];
     let output_info = reader.next_frame(&mut buf).map_err(|e| DecodeError::Png(e.to_string()))?;
     buf.truncate(output_info.buffer_size());
 
@@ -99,7 +338,8 @@ fn decode_png(data: &[u8]) -> Result<GraphicData, DecodeError> {
             (rgba, ColorType::Rgba)
         },
         png::ColorType::GrayscaleAlpha => {
-            let rgba: Vec<u8> = buf.chunks_exact(2).flat_map(|ga| [ga[0], ga[0], ga[0], ga[1]]).collect();
+            let rgba: Vec<u8> =
+                buf.chunks_exact(2).flat_map(|ga| [ga[0], ga[0], ga[0], ga[1]]).collect();
             (rgba, ColorType::Rgba)
         },
         png::ColorType::Grayscale => {
@@ -135,12 +375,17 @@ fn decode_raw(
     }
 
     let expected = w * h * bpp;
-    if data.len() != expected {
+    // Tolerate slightly more data than expected — some clients (e.g. chafa)
+    // produce a few extra trailing bytes due to base64 chunk alignment.
+    // Reject if data is too short or wildly too large (>1 row extra).
+    let max_tolerated = expected + w * bpp;
+    if data.len() < expected || data.len() > max_tolerated {
         return Err(DecodeError::InvalidDimensions(format!(
             "expected {expected} bytes for {w}x{h}x{bpp}, got {}",
             data.len()
         )));
     }
+    let data = &data[..expected];
 
     if w > MAX_IMAGE_WIDTH as usize || h > MAX_IMAGE_HEIGHT as usize {
         return Err(DecodeError::InvalidDimensions(format!(
@@ -160,11 +405,7 @@ fn decode_raw(
     })
 }
 
-fn decode_rgb_to_rgba(
-    data: &[u8],
-    width: u32,
-    height: u32,
-) -> Result<GraphicData, DecodeError> {
+fn decode_rgb_to_rgba(data: &[u8], width: u32, height: u32) -> Result<GraphicData, DecodeError> {
     let w = width as usize;
     let h = height as usize;
 
@@ -173,12 +414,14 @@ fn decode_rgb_to_rgba(
     }
 
     let expected = w * h * 3;
-    if data.len() != expected {
+    let max_tolerated = expected + w * 3;
+    if data.len() < expected || data.len() > max_tolerated {
         return Err(DecodeError::InvalidDimensions(format!(
             "expected {expected} bytes for {w}x{h}x3 (RGB), got {}",
             data.len()
         )));
     }
+    let data = &data[..expected];
 
     if w > MAX_IMAGE_WIDTH as usize || h > MAX_IMAGE_HEIGHT as usize {
         return Err(DecodeError::InvalidDimensions(format!(
@@ -212,18 +455,22 @@ pub fn rgb_bytes_to_rgba(rgb: &[u8]) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::graphics::kitty_parser::{Action, Compression, Format, KittyCommand};
+    use crate::graphics::kitty_parser::{Compression, Format, KittyCommand};
+
+    // ── Direct medium tests (existing) ─────────────────────────────────
 
     #[test]
     fn decode_raw_rgba() {
         let pixels: Vec<u8> = vec![
-            255, 0, 0, 255, 0, 255, 0, 255,
-            0, 0, 255, 255, 255, 255, 255, 255,
+            255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 255,
         ];
         let encoded = BASE64.encode(&pixels);
         let cmd = KittyCommand {
-            format: Format::Rgba, width: 2, height: 2,
-            payload: encoded.into_bytes(), ..Default::default()
+            format: Format::Rgba,
+            width: 2,
+            height: 2,
+            payload: encoded.into_bytes(),
+            ..Default::default()
         };
         let data = decode_payload(&cmd, &cmd.payload).unwrap();
         assert_eq!(data.width, 2);
@@ -236,29 +483,113 @@ mod tests {
         let rgb_pixels: Vec<u8> = vec![255, 0, 0, 0, 255, 0];
         let encoded = BASE64.encode(&rgb_pixels);
         let cmd = KittyCommand {
-            format: Format::Rgb, width: 2, height: 1,
-            payload: encoded.into_bytes(), ..Default::default()
+            format: Format::Rgb,
+            width: 2,
+            height: 1,
+            payload: encoded.into_bytes(),
+            ..Default::default()
         };
         let data = decode_payload(&cmd, &cmd.payload).unwrap();
         assert_eq!(data.pixels, vec![255, 0, 0, 255, 0, 255, 0, 255]);
     }
 
     #[test]
-    fn decode_dimension_mismatch() {
+    fn decode_dimension_mismatch_too_short() {
         let encoded = BASE64.encode(&[0u8; 10]);
         let cmd = KittyCommand {
-            format: Format::Rgba, width: 2, height: 2,
-            payload: encoded.into_bytes(), ..Default::default()
+            format: Format::Rgba,
+            width: 2,
+            height: 2,
+            payload: encoded.into_bytes(),
+            ..Default::default()
         };
         assert!(decode_payload(&cmd, &cmd.payload).is_err());
+    }
+
+    #[test]
+    fn decode_raw_truncates_slightly_over() {
+        // Simulates chafa sending 1 extra byte beyond the expected size.
+        // 2x2 RGBA = 16 bytes expected. Send 17 bytes — should truncate.
+        let mut pixels: Vec<u8> = vec![
+            255, 0, 0, 255, 0, 255, 0, 255,
+            0, 0, 255, 255, 255, 255, 255, 255,
+        ];
+        let expected = pixels.clone();
+        pixels.push(0xDE); // 1 extra trailing byte
+
+        let encoded = BASE64.encode(&pixels);
+        let cmd = KittyCommand {
+            format: Format::Rgba,
+            width: 2,
+            height: 2,
+            payload: encoded.into_bytes(),
+            ..Default::default()
+        };
+        let data = decode_payload(&cmd, &cmd.payload).unwrap();
+        assert_eq!(data.width, 2);
+        assert_eq!(data.height, 2);
+        assert_eq!(data.pixels, expected, "should truncate extra trailing byte");
+    }
+
+    #[test]
+    fn decode_raw_truncates_up_to_one_row_extra() {
+        // Up to one extra row of data should be tolerated.
+        // 4x4 RGBA = 64 bytes. One extra row = 16 bytes. Total = 80.
+        let pixels = vec![0u8; 80];
+        let encoded = BASE64.encode(&pixels);
+        let cmd = KittyCommand {
+            format: Format::Rgba,
+            width: 4,
+            height: 4,
+            payload: encoded.into_bytes(),
+            ..Default::default()
+        };
+        let data = decode_payload(&cmd, &cmd.payload).unwrap();
+        assert_eq!(data.pixels.len(), 64, "should truncate to expected 64 bytes");
+    }
+
+    #[test]
+    fn decode_raw_rejects_wildly_over() {
+        // More than one extra row should be rejected.
+        // 4x4 RGBA = 64 bytes. Two extra rows = 32 bytes. Total = 96.
+        let pixels = vec![0u8; 97]; // expected + row*4 + 1 = too much
+        let encoded = BASE64.encode(&pixels);
+        let cmd = KittyCommand {
+            format: Format::Rgba,
+            width: 4,
+            height: 4,
+            payload: encoded.into_bytes(),
+            ..Default::default()
+        };
+        assert!(decode_payload(&cmd, &cmd.payload).is_err());
+    }
+
+    #[test]
+    fn decode_rgb_truncates_slightly_over() {
+        // 2x1 RGB = 6 bytes. Send 7 — should truncate.
+        let mut pixels: Vec<u8> = vec![255, 0, 0, 0, 255, 0];
+        pixels.push(0xDE);
+        let encoded = BASE64.encode(&pixels);
+        let cmd = KittyCommand {
+            format: Format::Rgb,
+            width: 2,
+            height: 1,
+            payload: encoded.into_bytes(),
+            ..Default::default()
+        };
+        let data = decode_payload(&cmd, &cmd.payload).unwrap();
+        assert_eq!(data.pixels, vec![255, 0, 0, 255, 0, 255, 0, 255]);
     }
 
     #[test]
     fn decode_missing_dimensions() {
         let encoded = BASE64.encode(&[0u8; 16]);
         let cmd = KittyCommand {
-            format: Format::Rgba, width: 0, height: 0,
-            payload: encoded.into_bytes(), ..Default::default()
+            format: Format::Rgba,
+            width: 0,
+            height: 0,
+            payload: encoded.into_bytes(),
+            ..Default::default()
         };
         assert!(decode_payload(&cmd, &cmd.payload).is_err());
     }
@@ -273,8 +604,12 @@ mod tests {
         let compressed = encoder.finish().unwrap();
         let encoded = BASE64.encode(&compressed);
         let cmd = KittyCommand {
-            format: Format::Rgba, compression: Compression::Zlib,
-            width: 1, height: 1, payload: encoded.into_bytes(), ..Default::default()
+            format: Format::Rgba,
+            compression: Compression::Zlib,
+            width: 1,
+            height: 1,
+            payload: encoded.into_bytes(),
+            ..Default::default()
         };
         let data = decode_payload(&cmd, &cmd.payload).unwrap();
         assert_eq!(data.pixels, pixels);
@@ -292,7 +627,9 @@ mod tests {
         }
         let encoded = BASE64.encode(&png_buf);
         let cmd = KittyCommand {
-            format: Format::Png, payload: encoded.into_bytes(), ..Default::default()
+            format: Format::Png,
+            payload: encoded.into_bytes(),
+            ..Default::default()
         };
         let data = decode_payload(&cmd, &cmd.payload).unwrap();
         assert_eq!(data.pixels, vec![255, 0, 0, 255]);
@@ -303,5 +640,474 @@ mod tests {
         let rgb = vec![255, 0, 0, 0, 255, 0];
         let rgba = rgb_bytes_to_rgba(&rgb);
         assert_eq!(rgba, vec![255, 0, 0, 255, 0, 255, 0, 255]);
+    }
+
+    #[test]
+    fn decode_direct_with_padding_in_payload() {
+        // Simulates chunked transfer where intermediate chunks include
+        // trailing `=` padding (as chafa does). When chunks are merged,
+        // `=` ends up in the middle of the base64 string.
+        let pixels: Vec<u8> = vec![
+            255, 0, 0, 255, 0, 255, 0, 255,
+            0, 0, 255, 255, 255, 255, 255, 255,
+        ];
+        let full_b64 = BASE64.encode(&pixels);
+
+        // Split the base64 in the middle and add `=` padding to chunk 1,
+        // simulating what a client like chafa would send across two APC
+        // sequences that we then concatenate.
+        let mid = full_b64.len() / 2;
+        let chunk1 = &full_b64[..mid];
+        let chunk2 = &full_b64[mid..];
+        let merged_with_padding = format!("{chunk1}=={chunk2}");
+
+        let cmd = KittyCommand {
+            format: Format::Rgba, width: 2, height: 2,
+            payload: merged_with_padding.into_bytes(), ..Default::default()
+        };
+        let data = decode_payload(&cmd, &cmd.payload).unwrap();
+        assert_eq!(data.width, 2);
+        assert_eq!(data.height, 2);
+        assert_eq!(data.pixels, pixels);
+    }
+
+    #[test]
+    fn decode_direct_with_trailing_padding() {
+        // Standard base64 with trailing `=` padding should also work.
+        let pixels: Vec<u8> = vec![255, 0, 0, 255, 0, 255, 0]; // 7 bytes → padded b64
+        let b64_padded = BASE64.encode(&pixels);
+        assert!(b64_padded.contains('='), "test expects padded base64");
+
+        let cmd = KittyCommand {
+            format: Format::Rgba, width: 0, height: 0,
+            payload: b64_padded.into_bytes(), ..Default::default()
+        };
+        // Will fail on dimension check, but should NOT fail on base64 decode.
+        let err = decode_payload(&cmd, &cmd.payload).unwrap_err();
+        assert!(!err.to_string().contains("base64"), "should not be a base64 error, got: {err}");
+    }
+
+    // ── File medium tests ──────────────────────────────────────────────
+
+    #[test]
+    fn decode_file_medium_rgba() {
+        use std::io::Write;
+
+        // 2x1 RGBA pixel data: red + green.
+        let pixels: Vec<u8> = vec![255, 0, 0, 255, 0, 255, 0, 255];
+
+        let temp_dir = std::env::temp_dir();
+        let file_path = temp_dir.join(format!("kitty_test_file_{}", std::process::id()));
+        {
+            let mut f = std::fs::File::create(&file_path).unwrap();
+            f.write_all(&pixels).unwrap();
+        }
+
+        let path_b64 = BASE64.encode(file_path.to_str().unwrap().as_bytes());
+        let cmd = KittyCommand {
+            format: Format::Rgba,
+            medium: Medium::File,
+            width: 2,
+            height: 1,
+            payload: path_b64.clone().into_bytes(),
+            ..Default::default()
+        };
+
+        let data = decode_payload(&cmd, &cmd.payload).unwrap();
+        assert_eq!(data.width, 2);
+        assert_eq!(data.height, 1);
+        assert_eq!(data.pixels, pixels);
+
+        // Clean up (File medium does NOT delete the file).
+        let _ = std::fs::remove_file(&file_path);
+    }
+
+    #[test]
+    fn decode_file_medium_with_offset_and_size() {
+        use std::io::Write;
+
+        // Write 16 bytes: [header(4)] [pixels(8)] [trailer(4)]
+        let header = [0xDE, 0xAD, 0xBE, 0xEF];
+        let pixels: Vec<u8> = vec![255, 0, 0, 255, 0, 255, 0, 255];
+        let trailer = [0xCA, 0xFE, 0xBA, 0xBE];
+
+        let temp_dir = std::env::temp_dir();
+        let file_path = temp_dir.join(format!("kitty_test_offset_{}", std::process::id()));
+        {
+            let mut f = std::fs::File::create(&file_path).unwrap();
+            f.write_all(&header).unwrap();
+            f.write_all(&pixels).unwrap();
+            f.write_all(&trailer).unwrap();
+        }
+
+        let path_b64 = BASE64.encode(file_path.to_str().unwrap().as_bytes());
+        let cmd = KittyCommand {
+            format: Format::Rgba,
+            medium: Medium::File,
+            width: 2,
+            height: 1,
+            data_offset: 4,
+            data_size: 8,
+            payload: path_b64.into_bytes(),
+            ..Default::default()
+        };
+
+        let data = decode_payload(&cmd, &cmd.payload).unwrap();
+        assert_eq!(data.pixels, pixels);
+
+        let _ = std::fs::remove_file(&file_path);
+    }
+
+    #[test]
+    fn decode_tempfile_medium_deletes_after_read() {
+        use std::io::Write;
+
+        let pixels: Vec<u8> = vec![255, 0, 0, 255, 0, 255, 0, 255];
+
+        let temp_dir = std::env::temp_dir();
+        let file_name = format!("kitty_test_tempfile_{}", std::process::id());
+        let file_path = temp_dir.join(&file_name);
+        {
+            let mut f = std::fs::File::create(&file_path).unwrap();
+            f.write_all(&pixels).unwrap();
+        }
+
+        assert!(file_path.exists(), "temp file should exist before decode");
+
+        // For TempFile, the payload is the base64-encoded *relative* path (filename only).
+        let path_b64 = BASE64.encode(file_name.as_bytes());
+        let cmd = KittyCommand {
+            format: Format::Rgba,
+            medium: Medium::TempFile,
+            width: 2,
+            height: 1,
+            payload: path_b64.into_bytes(),
+            ..Default::default()
+        };
+
+        let data = decode_payload(&cmd, &cmd.payload).unwrap();
+        assert_eq!(data.pixels, pixels);
+
+        // TempFile medium should delete the file after reading.
+        assert!(!file_path.exists(), "temp file should be deleted after decode");
+    }
+
+    #[test]
+    fn decode_tempfile_rejects_parent_dir_traversal() {
+        let evil_path = "../etc/passwd";
+        let path_b64 = BASE64.encode(evil_path.as_bytes());
+        let cmd = KittyCommand {
+            format: Format::Rgba,
+            medium: Medium::TempFile,
+            width: 1,
+            height: 1,
+            payload: path_b64.into_bytes(),
+            ..Default::default()
+        };
+
+        let err = decode_payload(&cmd, &cmd.payload).unwrap_err();
+        assert!(
+            matches!(err, DecodeError::PathTraversal(_)),
+            "expected PathTraversal error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn decode_tempfile_rejects_double_dot_in_middle() {
+        let evil_path = "subdir/../../etc/passwd";
+        let path_b64 = BASE64.encode(evil_path.as_bytes());
+        let cmd = KittyCommand {
+            format: Format::Rgba,
+            medium: Medium::TempFile,
+            width: 1,
+            height: 1,
+            payload: path_b64.into_bytes(),
+            ..Default::default()
+        };
+
+        let err = decode_payload(&cmd, &cmd.payload).unwrap_err();
+        assert!(
+            matches!(err, DecodeError::PathTraversal(_)),
+            "expected PathTraversal error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn decode_tempfile_rejects_absolute_path() {
+        let evil_path = "/etc/passwd";
+        let path_b64 = BASE64.encode(evil_path.as_bytes());
+        let cmd = KittyCommand {
+            format: Format::Rgba,
+            medium: Medium::TempFile,
+            width: 1,
+            height: 1,
+            payload: path_b64.into_bytes(),
+            ..Default::default()
+        };
+
+        let err = decode_payload(&cmd, &cmd.payload).unwrap_err();
+        assert!(
+            matches!(err, DecodeError::PathTraversal(_)),
+            "expected PathTraversal error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn decode_file_medium_with_zlib() {
+        use flate2::write::ZlibEncoder;
+        use std::io::Write;
+
+        let pixels: Vec<u8> = vec![255, 0, 0, 255];
+        let mut enc = ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+        enc.write_all(&pixels).unwrap();
+        let compressed = enc.finish().unwrap();
+
+        let temp_dir = std::env::temp_dir();
+        let file_path = temp_dir.join(format!("kitty_test_zlib_{}", std::process::id()));
+        {
+            let mut f = std::fs::File::create(&file_path).unwrap();
+            f.write_all(&compressed).unwrap();
+        }
+
+        let path_b64 = BASE64.encode(file_path.to_str().unwrap().as_bytes());
+        let cmd = KittyCommand {
+            format: Format::Rgba,
+            medium: Medium::File,
+            compression: Compression::Zlib,
+            width: 1,
+            height: 1,
+            payload: path_b64.into_bytes(),
+            ..Default::default()
+        };
+
+        let data = decode_payload(&cmd, &cmd.payload).unwrap();
+        assert_eq!(data.pixels, pixels);
+
+        let _ = std::fs::remove_file(&file_path);
+    }
+
+    #[test]
+    fn decode_file_medium_png() {
+        use std::io::Write;
+
+        let mut png_buf = Vec::new();
+        {
+            let mut encoder = png::Encoder::new(&mut png_buf, 1, 1);
+            encoder.set_color(png::ColorType::Rgba);
+            encoder.set_depth(png::BitDepth::Eight);
+            let mut writer = encoder.write_header().unwrap();
+            writer.write_image_data(&[0, 128, 255, 200]).unwrap();
+        }
+
+        let temp_dir = std::env::temp_dir();
+        let file_path = temp_dir.join(format!("kitty_test_png_{}", std::process::id()));
+        {
+            let mut f = std::fs::File::create(&file_path).unwrap();
+            f.write_all(&png_buf).unwrap();
+        }
+
+        let path_b64 = BASE64.encode(file_path.to_str().unwrap().as_bytes());
+        let cmd = KittyCommand {
+            format: Format::Png,
+            medium: Medium::File,
+            payload: path_b64.into_bytes(),
+            ..Default::default()
+        };
+
+        let data = decode_payload(&cmd, &cmd.payload).unwrap();
+        assert_eq!(data.pixels, vec![0, 128, 255, 200]);
+        assert_eq!(data.width, 1);
+        assert_eq!(data.height, 1);
+
+        let _ = std::fs::remove_file(&file_path);
+    }
+
+    // ── SharedMemory tests (unix only) ─────────────────────────────────
+
+    #[cfg(unix)]
+    mod shm_tests {
+        use super::*;
+        use std::ffi::CString;
+
+        /// Helper: create a POSIX shared memory object with given data, return the name.
+        fn create_shm(name: &str, data: &[u8]) -> CString {
+            let c_name = CString::new(name).unwrap();
+            unsafe {
+                let fd = libc::shm_open(
+                    c_name.as_ptr(),
+                    libc::O_CREAT | libc::O_RDWR,
+                    0o600,
+                );
+                assert!(fd >= 0, "shm_open failed: {}", std::io::Error::last_os_error());
+
+                let ret = libc::ftruncate(fd, data.len() as libc::off_t);
+                assert_eq!(ret, 0, "ftruncate failed");
+
+                let ptr = libc::mmap(
+                    std::ptr::null_mut(),
+                    data.len(),
+                    libc::PROT_WRITE,
+                    libc::MAP_SHARED,
+                    fd,
+                    0,
+                );
+                assert_ne!(ptr, libc::MAP_FAILED, "mmap failed");
+
+                std::ptr::copy_nonoverlapping(data.as_ptr(), ptr as *mut u8, data.len());
+
+                libc::munmap(ptr, data.len());
+                libc::close(fd);
+            }
+            c_name
+        }
+
+        /// Check if a shm object still exists.
+        fn shm_exists(name: &str) -> bool {
+            let c_name = CString::new(name).unwrap();
+            let fd = unsafe { libc::shm_open(c_name.as_ptr(), libc::O_RDONLY, 0) };
+            if fd >= 0 {
+                unsafe { libc::close(fd) };
+                // Clean up the check-open by unlinking if it exists.
+                // Actually, we just want to probe, not unlink. If it was
+                // supposed to be gone, this tells us it's still there.
+                true
+            } else {
+                false
+            }
+        }
+
+        #[test]
+        fn decode_shm_medium_rgba() {
+            let shm_name = format!("/kitty_test_shm_{}", std::process::id());
+            let pixels: Vec<u8> = vec![255, 0, 0, 255, 0, 255, 0, 255];
+
+            create_shm(&shm_name, &pixels);
+
+            let name_b64 = BASE64.encode(shm_name.as_bytes());
+            let cmd = KittyCommand {
+                format: Format::Rgba,
+                medium: Medium::SharedMemory,
+                width: 2,
+                height: 1,
+                // S= is required for shm: macOS allocates page-aligned regions,
+                // so the fstat size may exceed the actual payload length.
+                data_size: pixels.len() as u32,
+                payload: name_b64.into_bytes(),
+                ..Default::default()
+            };
+
+            let data = decode_payload(&cmd, &cmd.payload).unwrap();
+            assert_eq!(data.width, 2);
+            assert_eq!(data.height, 1);
+            assert_eq!(data.pixels, pixels);
+
+            // Verify shm was unlinked.
+            assert!(!shm_exists(&shm_name), "shm should be unlinked after decode");
+        }
+
+        #[test]
+        fn decode_shm_medium_with_offset_and_size() {
+            let shm_name = format!("/kitty_test_shm_off_{}", std::process::id());
+
+            // Write: [header(4)] [pixels(8)] [trailer(4)]
+            let mut full_data = vec![0xDE, 0xAD, 0xBE, 0xEF];
+            let pixels: Vec<u8> = vec![10, 20, 30, 255, 40, 50, 60, 255];
+            full_data.extend_from_slice(&pixels);
+            full_data.extend_from_slice(&[0xCA, 0xFE, 0xBA, 0xBE]);
+
+            create_shm(&shm_name, &full_data);
+
+            let name_b64 = BASE64.encode(shm_name.as_bytes());
+            let cmd = KittyCommand {
+                format: Format::Rgba,
+                medium: Medium::SharedMemory,
+                width: 2,
+                height: 1,
+                data_offset: 4,
+                data_size: 8,
+                payload: name_b64.into_bytes(),
+                ..Default::default()
+            };
+
+            let data = decode_payload(&cmd, &cmd.payload).unwrap();
+            assert_eq!(data.pixels, pixels);
+
+            assert!(!shm_exists(&shm_name), "shm should be unlinked after decode");
+        }
+
+        #[test]
+        fn decode_shm_medium_cleanup_on_success() {
+            let shm_name = format!("/kitty_test_shm_clean_{}", std::process::id());
+            let pixels: Vec<u8> = vec![100, 200, 50, 255];
+
+            create_shm(&shm_name, &pixels);
+            assert!(shm_exists(&shm_name), "shm should exist before decode");
+
+            let name_b64 = BASE64.encode(shm_name.as_bytes());
+            let cmd = KittyCommand {
+                format: Format::Rgba,
+                medium: Medium::SharedMemory,
+                width: 1,
+                height: 1,
+                data_size: pixels.len() as u32,
+                payload: name_b64.into_bytes(),
+                ..Default::default()
+            };
+
+            let data = decode_payload(&cmd, &cmd.payload).unwrap();
+            assert_eq!(data.pixels, pixels);
+
+            // The shm should be fully cleaned up.
+            assert!(!shm_exists(&shm_name), "shm must be cleaned up after decode");
+        }
+
+        #[test]
+        fn decode_shm_nonexistent_returns_error() {
+            let shm_name = "/kitty_test_shm_nonexistent_999999";
+
+            let name_b64 = BASE64.encode(shm_name.as_bytes());
+            let cmd = KittyCommand {
+                format: Format::Rgba,
+                medium: Medium::SharedMemory,
+                width: 1,
+                height: 1,
+                payload: name_b64.into_bytes(),
+                ..Default::default()
+            };
+
+            let err = decode_payload(&cmd, &cmd.payload);
+            assert!(err.is_err(), "nonexistent shm should error");
+        }
+    }
+
+    // ── validate_temp_path unit tests ──────────────────────────────────
+
+    #[test]
+    fn validate_temp_path_simple_filename() {
+        assert!(validate_temp_path("image.png").is_ok());
+    }
+
+    #[test]
+    fn validate_temp_path_subdir() {
+        assert!(validate_temp_path("subdir/image.png").is_ok());
+    }
+
+    #[test]
+    fn validate_temp_path_dot_component() {
+        // Current-dir "." is harmless.
+        assert!(validate_temp_path("./image.png").is_ok());
+    }
+
+    #[test]
+    fn validate_temp_path_rejects_parent() {
+        assert!(validate_temp_path("..").is_err());
+        assert!(validate_temp_path("../image.png").is_err());
+        assert!(validate_temp_path("a/../b").is_err());
+    }
+
+    #[test]
+    fn validate_temp_path_rejects_absolute() {
+        assert!(validate_temp_path("/etc/passwd").is_err());
+        assert!(validate_temp_path("/tmp/file").is_err());
     }
 }

--- a/alacritty_terminal/src/graphics/kitty/decode.rs
+++ b/alacritty_terminal/src/graphics/kitty/decode.rs
@@ -1,0 +1,307 @@
+//! Kitty graphics payload decode pipeline.
+//!
+//! Pipeline: base64 → zlib (optional) → format decode → GraphicData
+
+use std::io::Read;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use flate2::read::ZlibDecoder;
+
+use crate::graphics::kitty_parser::{Compression, Format, KittyCommand, Medium};
+use crate::graphics::{ColorType, GraphicData, MAX_GRAPHIC_DIMENSIONS};
+
+/// Maximum dimensions for a single image.
+const MAX_IMAGE_WIDTH: u32 = 10000;
+const MAX_IMAGE_HEIGHT: u32 = 10000;
+
+/// Errors that can occur during kitty image decoding.
+#[derive(Debug)]
+pub enum DecodeError {
+    Base64(String),
+    Zlib(String),
+    Png(String),
+    InvalidDimensions(String),
+    UnsupportedMedium(Medium),
+    MissingDimensions,
+}
+
+impl std::fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DecodeError::Base64(e) => write!(f, "base64 decode error: {e}"),
+            DecodeError::Zlib(e) => write!(f, "zlib decompress error: {e}"),
+            DecodeError::Png(e) => write!(f, "PNG decode error: {e}"),
+            DecodeError::InvalidDimensions(e) => write!(f, "invalid dimensions: {e}"),
+            DecodeError::UnsupportedMedium(m) => write!(f, "unsupported medium: {m:?}"),
+            DecodeError::MissingDimensions => write!(f, "missing width/height for raw format"),
+        }
+    }
+}
+
+/// Decode a kitty graphics payload into a `GraphicData`.
+///
+/// Pipeline: base64 → zlib (optional) → format decode → GraphicData
+pub fn decode_payload(cmd: &KittyCommand, raw_payload: &[u8]) -> Result<GraphicData, DecodeError> {
+    if cmd.medium != Medium::Direct {
+        return Err(DecodeError::UnsupportedMedium(cmd.medium));
+    }
+
+    let decoded = BASE64
+        .decode(raw_payload)
+        .map_err(|e| DecodeError::Base64(e.to_string()))?;
+
+    let decompressed = match cmd.compression {
+        Compression::Zlib => {
+            let mut decoder = ZlibDecoder::new(&decoded[..]);
+            let mut buf = Vec::new();
+            decoder.read_to_end(&mut buf).map_err(|e| DecodeError::Zlib(e.to_string()))?;
+            buf
+        },
+        Compression::None => decoded,
+    };
+
+    match cmd.format {
+        Format::Png => decode_png(&decompressed),
+        Format::Rgba => decode_raw(&decompressed, cmd.width, cmd.height, 4),
+        Format::Rgb => decode_rgb_to_rgba(&decompressed, cmd.width, cmd.height),
+    }
+}
+
+fn decode_png(data: &[u8]) -> Result<GraphicData, DecodeError> {
+    let decoder = png::Decoder::new(data);
+    let mut reader = decoder.read_info().map_err(|e| DecodeError::Png(e.to_string()))?;
+
+    let info = reader.info();
+    let width = info.width as usize;
+    let height = info.height as usize;
+
+    if width > MAX_IMAGE_WIDTH as usize || height > MAX_IMAGE_HEIGHT as usize {
+        return Err(DecodeError::InvalidDimensions(format!(
+            "PNG {width}x{height} exceeds max {MAX_IMAGE_WIDTH}x{MAX_IMAGE_HEIGHT}"
+        )));
+    }
+
+    if width > MAX_GRAPHIC_DIMENSIONS[0] || height > MAX_GRAPHIC_DIMENSIONS[1] {
+        return Err(DecodeError::InvalidDimensions(format!(
+            "PNG {width}x{height} exceeds max graphic dimensions"
+        )));
+    }
+
+    let mut buf = vec![0u8; reader.output_buffer_size()];
+    let output_info = reader.next_frame(&mut buf).map_err(|e| DecodeError::Png(e.to_string()))?;
+    buf.truncate(output_info.buffer_size());
+
+    let (pixels, color_type) = match output_info.color_type {
+        png::ColorType::Rgba => (buf, ColorType::Rgba),
+        png::ColorType::Rgb => {
+            let rgba = rgb_bytes_to_rgba(&buf);
+            (rgba, ColorType::Rgba)
+        },
+        png::ColorType::GrayscaleAlpha => {
+            let rgba: Vec<u8> = buf.chunks_exact(2).flat_map(|ga| [ga[0], ga[0], ga[0], ga[1]]).collect();
+            (rgba, ColorType::Rgba)
+        },
+        png::ColorType::Grayscale => {
+            let rgba: Vec<u8> = buf.iter().flat_map(|&g| [g, g, g, 255]).collect();
+            (rgba, ColorType::Rgba)
+        },
+        png::ColorType::Indexed => {
+            return Err(DecodeError::Png("indexed PNG not directly supported".into()));
+        },
+    };
+
+    Ok(GraphicData {
+        id: crate::graphics::GraphicId(0),
+        width,
+        height,
+        color_type,
+        pixels,
+        is_opaque: color_type == ColorType::Rgb,
+    })
+}
+
+fn decode_raw(
+    data: &[u8],
+    width: u32,
+    height: u32,
+    bpp: usize,
+) -> Result<GraphicData, DecodeError> {
+    let w = width as usize;
+    let h = height as usize;
+
+    if w == 0 || h == 0 {
+        return Err(DecodeError::MissingDimensions);
+    }
+
+    let expected = w * h * bpp;
+    if data.len() != expected {
+        return Err(DecodeError::InvalidDimensions(format!(
+            "expected {expected} bytes for {w}x{h}x{bpp}, got {}",
+            data.len()
+        )));
+    }
+
+    if w > MAX_IMAGE_WIDTH as usize || h > MAX_IMAGE_HEIGHT as usize {
+        return Err(DecodeError::InvalidDimensions(format!(
+            "{w}x{h} exceeds max {MAX_IMAGE_WIDTH}x{MAX_IMAGE_HEIGHT}"
+        )));
+    }
+
+    let color_type = if bpp == 4 { ColorType::Rgba } else { ColorType::Rgb };
+
+    Ok(GraphicData {
+        id: crate::graphics::GraphicId(0),
+        width: w,
+        height: h,
+        color_type,
+        pixels: data.to_vec(),
+        is_opaque: bpp == 3,
+    })
+}
+
+fn decode_rgb_to_rgba(
+    data: &[u8],
+    width: u32,
+    height: u32,
+) -> Result<GraphicData, DecodeError> {
+    let w = width as usize;
+    let h = height as usize;
+
+    if w == 0 || h == 0 {
+        return Err(DecodeError::MissingDimensions);
+    }
+
+    let expected = w * h * 3;
+    if data.len() != expected {
+        return Err(DecodeError::InvalidDimensions(format!(
+            "expected {expected} bytes for {w}x{h}x3 (RGB), got {}",
+            data.len()
+        )));
+    }
+
+    if w > MAX_IMAGE_WIDTH as usize || h > MAX_IMAGE_HEIGHT as usize {
+        return Err(DecodeError::InvalidDimensions(format!(
+            "{w}x{h} exceeds max {MAX_IMAGE_WIDTH}x{MAX_IMAGE_HEIGHT}"
+        )));
+    }
+
+    let rgba = rgb_bytes_to_rgba(data);
+
+    Ok(GraphicData {
+        id: crate::graphics::GraphicId(0),
+        width: w,
+        height: h,
+        color_type: ColorType::Rgba,
+        pixels: rgba,
+        is_opaque: true,
+    })
+}
+
+/// Convert an RGB byte slice to RGBA (fully opaque).
+pub fn rgb_bytes_to_rgba(rgb: &[u8]) -> Vec<u8> {
+    let pixel_count = rgb.len() / 3;
+    let mut rgba = Vec::with_capacity(pixel_count * 4);
+    for chunk in rgb.chunks_exact(3) {
+        rgba.extend_from_slice(chunk);
+        rgba.push(255);
+    }
+    rgba
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graphics::kitty_parser::{Action, Compression, Format, KittyCommand};
+
+    #[test]
+    fn decode_raw_rgba() {
+        let pixels: Vec<u8> = vec![
+            255, 0, 0, 255, 0, 255, 0, 255,
+            0, 0, 255, 255, 255, 255, 255, 255,
+        ];
+        let encoded = BASE64.encode(&pixels);
+        let cmd = KittyCommand {
+            format: Format::Rgba, width: 2, height: 2,
+            payload: encoded.into_bytes(), ..Default::default()
+        };
+        let data = decode_payload(&cmd, &cmd.payload).unwrap();
+        assert_eq!(data.width, 2);
+        assert_eq!(data.height, 2);
+        assert_eq!(data.pixels, pixels);
+    }
+
+    #[test]
+    fn decode_raw_rgb() {
+        let rgb_pixels: Vec<u8> = vec![255, 0, 0, 0, 255, 0];
+        let encoded = BASE64.encode(&rgb_pixels);
+        let cmd = KittyCommand {
+            format: Format::Rgb, width: 2, height: 1,
+            payload: encoded.into_bytes(), ..Default::default()
+        };
+        let data = decode_payload(&cmd, &cmd.payload).unwrap();
+        assert_eq!(data.pixels, vec![255, 0, 0, 255, 0, 255, 0, 255]);
+    }
+
+    #[test]
+    fn decode_dimension_mismatch() {
+        let encoded = BASE64.encode(&[0u8; 10]);
+        let cmd = KittyCommand {
+            format: Format::Rgba, width: 2, height: 2,
+            payload: encoded.into_bytes(), ..Default::default()
+        };
+        assert!(decode_payload(&cmd, &cmd.payload).is_err());
+    }
+
+    #[test]
+    fn decode_missing_dimensions() {
+        let encoded = BASE64.encode(&[0u8; 16]);
+        let cmd = KittyCommand {
+            format: Format::Rgba, width: 0, height: 0,
+            payload: encoded.into_bytes(), ..Default::default()
+        };
+        assert!(decode_payload(&cmd, &cmd.payload).is_err());
+    }
+
+    #[test]
+    fn decode_zlib_compressed() {
+        use flate2::write::ZlibEncoder;
+        use std::io::Write;
+        let pixels: Vec<u8> = vec![255, 128, 64, 255];
+        let mut encoder = ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(&pixels).unwrap();
+        let compressed = encoder.finish().unwrap();
+        let encoded = BASE64.encode(&compressed);
+        let cmd = KittyCommand {
+            format: Format::Rgba, compression: Compression::Zlib,
+            width: 1, height: 1, payload: encoded.into_bytes(), ..Default::default()
+        };
+        let data = decode_payload(&cmd, &cmd.payload).unwrap();
+        assert_eq!(data.pixels, pixels);
+    }
+
+    #[test]
+    fn decode_png_image() {
+        let mut png_buf = Vec::new();
+        {
+            let mut encoder = png::Encoder::new(&mut png_buf, 1, 1);
+            encoder.set_color(png::ColorType::Rgba);
+            encoder.set_depth(png::BitDepth::Eight);
+            let mut writer = encoder.write_header().unwrap();
+            writer.write_image_data(&[255, 0, 0, 255]).unwrap();
+        }
+        let encoded = BASE64.encode(&png_buf);
+        let cmd = KittyCommand {
+            format: Format::Png, payload: encoded.into_bytes(), ..Default::default()
+        };
+        let data = decode_payload(&cmd, &cmd.payload).unwrap();
+        assert_eq!(data.pixels, vec![255, 0, 0, 255]);
+    }
+
+    #[test]
+    fn rgb_to_rgba_conversion() {
+        let rgb = vec![255, 0, 0, 0, 255, 0];
+        let rgba = rgb_bytes_to_rgba(&rgb);
+        assert_eq!(rgba, vec![255, 0, 0, 255, 0, 255, 0, 255]);
+    }
+}

--- a/alacritty_terminal/src/graphics/kitty/mod.rs
+++ b/alacritty_terminal/src/graphics/kitty/mod.rs
@@ -8,6 +8,7 @@
 //!
 //! See: <https://sw.kovidgoyal.net/kitty/graphics-protocol/>
 
+pub mod animation;
 pub mod decode;
 pub mod placement;
 pub mod response;
@@ -16,10 +17,10 @@ pub mod state;
 use log::{debug, trace};
 
 use crate::event::EventListener;
-use crate::graphics::kitty_parser::{Action, DeleteTarget, KittyCommand};
+use crate::graphics::kitty_parser::{Action, DeleteTarget, KittyCommand, Medium};
 use crate::term::Term;
 
-pub use self::state::{KittyImage, KittyLoadingImage, KittyState};
+pub use self::state::{KittyImage, KittyLoadingImage, KittyPlacement, KittyState};
 
 use self::decode::decode_payload;
 use self::placement::{place_image, resolve_image_id, resolve_or_assign_id};
@@ -66,62 +67,96 @@ pub fn dispatch_command<L: EventListener>(term: &mut Term<L>, cmd: KittyCommand)
         Action::Delete => {
             handle_delete(term, &cmd);
         },
-        // Phase 3: Animation (stub).
         Action::TransmitFrame => {
-            debug!("[kitty] TransmitFrame not yet implemented");
-            send_response(
-                term.event_proxy(),
-                quiet,
-                image_id,
-                &Err("animation frames not yet supported".into()),
+            let result = animation::load_animation_frame(
+                &mut term.graphics.kitty_state,
+                &cmd,
+                &cmd.payload,
             );
+            send_response(term.event_proxy(), quiet, image_id, &result);
         },
         Action::AnimationControl => {
-            debug!("[kitty] AnimationControl not yet implemented");
+            animation::control_animation(&mut term.graphics.kitty_state, &cmd);
         },
         Action::ComposeFrames => {
-            debug!("[kitty] ComposeFrames not yet implemented");
-            send_response(
-                term.event_proxy(),
-                quiet,
-                image_id,
-                &Err("frame composition not yet supported".into()),
-            );
+            let result = animation::compose_frames(&mut term.graphics.kitty_state, &cmd);
+            send_response(term.event_proxy(), quiet, image_id, &result);
         },
     }
 }
 
 // ── Chunked Transfer ───────────────────────────────────────────────────
 
+/// Decode a single chunk's base64 payload into raw bytes.
+///
+/// For `Medium::Direct`, this decodes base64 immediately. For file/shm
+/// mediums the payload is a path, so we pass it through unchanged (it
+/// will only appear in single-shot transfers, not chunked).
+fn decode_chunk_payload(medium: Medium, payload: &[u8]) -> Vec<u8> {
+    if payload.is_empty() {
+        return Vec::new();
+    }
+
+    if medium != Medium::Direct {
+        // File/shm mediums: payload is a base64 path — keep as-is.
+        return payload.to_vec();
+    }
+
+    // Decode this chunk's base64 independently. This handles clients
+    // like chafa that base64-encode each chunk separately (with padding)
+    // rather than splitting one big base64 string across chunks.
+    use base64::Engine;
+    use base64::alphabet;
+    use base64::engine::{GeneralPurpose, GeneralPurposeConfig, DecodePaddingMode};
+
+    const B64: GeneralPurpose = GeneralPurpose::new(
+        &alphabet::STANDARD,
+        GeneralPurposeConfig::new().with_decode_padding_mode(DecodePaddingMode::Indifferent),
+    );
+
+    match B64.decode(payload) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            debug!("[kitty] chunk base64 decode error: {e}");
+            Vec::new()
+        },
+    }
+}
+
 /// Start or continue a chunked transfer (m=1).
 fn handle_chunk_start<L: EventListener>(term: &mut Term<L>, cmd: KittyCommand) {
-    let payload = cmd.payload.clone();
+    let decoded = decode_chunk_payload(cmd.medium, &cmd.payload);
 
     match &mut term.graphics.kitty_state.loading {
         Some(loading) => {
-            loading.payload.extend_from_slice(&payload);
+            loading.data.extend_from_slice(&decoded);
             trace!(
-                "[kitty] chunk appended, total payload: {} bytes",
-                loading.payload.len()
+                "[kitty] chunk appended, total decoded: {} bytes",
+                loading.data.len()
             );
         },
         None => {
-            trace!("[kitty] starting chunked transfer, first chunk: {} bytes", payload.len());
+            trace!("[kitty] starting chunked transfer, first chunk: {} decoded bytes", decoded.len());
             term.graphics.kitty_state.loading = Some(KittyLoadingImage {
                 command: cmd,
-                payload,
+                data: decoded,
             });
         },
     }
 }
 
 /// Finalize a chunked transfer by merging the last chunk.
+///
+/// Returns a command whose `payload` contains the fully decoded raw bytes
+/// and whose `pre_decoded` flag is set so `decode_payload` skips base64.
 fn finalize_chunked(mut loading: KittyLoadingImage, final_cmd: KittyCommand) -> KittyCommand {
-    loading.payload.extend_from_slice(&final_cmd.payload);
+    let decoded = decode_chunk_payload(loading.command.medium, &final_cmd.payload);
+    loading.data.extend_from_slice(&decoded);
 
     let mut cmd = loading.command;
-    cmd.payload = loading.payload;
+    cmd.payload = loading.data;
     cmd.more_chunks = false;
+    cmd.pre_decoded = true;
     cmd
 }
 
@@ -197,8 +232,10 @@ fn handle_display<L: EventListener>(
 /// Handle `a=d` (delete).
 fn handle_delete<L: EventListener>(term: &mut Term<L>, cmd: &KittyCommand) {
     let target = cmd.delete.unwrap_or(DeleteTarget::All);
+    let cursor_col = term.grid().cursor.point.column.0;
+    let cursor_row = term.grid().cursor.point.line.0 as usize;
     debug!("[kitty] delete: {target:?}, image_id={}, image_number={}", cmd.image_id, cmd.image_number);
-    term.graphics.kitty_state.delete(target, cmd);
+    term.graphics.kitty_state.delete(target, cmd, cursor_col, cursor_row);
 }
 
 #[cfg(test)]
@@ -207,7 +244,8 @@ mod tests {
     use crate::graphics::kitty_parser::{Action, Format};
 
     #[test]
-    fn finalize_chunked_merges_payloads() {
+    fn finalize_chunked_merges_decoded_bytes() {
+        // KittyLoadingImage now holds already-decoded bytes (not base64).
         let loading = KittyLoadingImage {
             command: KittyCommand {
                 action: Action::TransmitAndDisplay,
@@ -215,11 +253,16 @@ mod tests {
                 image_id: 5,
                 ..Default::default()
             },
-            payload: b"AAAA".to_vec(),
+            data: vec![0xDE, 0xAD],
         };
 
+        // The final chunk's payload is still base64 — finalize_chunked
+        // decodes it via decode_chunk_payload before appending.
+        use base64::Engine;
+        let final_bytes = vec![0xBE, 0xEF];
+        let final_b64 = base64::engine::general_purpose::STANDARD.encode(&final_bytes);
         let final_cmd = KittyCommand {
-            payload: b"BBBB".to_vec(),
+            payload: final_b64.into_bytes(),
             ..Default::default()
         };
 
@@ -227,7 +270,8 @@ mod tests {
         assert_eq!(merged.action, Action::TransmitAndDisplay);
         assert_eq!(merged.format, Format::Png);
         assert_eq!(merged.image_id, 5);
-        assert_eq!(merged.payload, b"AAAABBBB");
+        assert_eq!(merged.payload, vec![0xDE, 0xAD, 0xBE, 0xEF]);
         assert!(!merged.more_chunks);
+        assert!(merged.pre_decoded);
     }
 }

--- a/alacritty_terminal/src/graphics/kitty/mod.rs
+++ b/alacritty_terminal/src/graphics/kitty/mod.rs
@@ -1,0 +1,233 @@
+//! Kitty graphics protocol implementation.
+//!
+//! This module is split into submodules for parallel development:
+//! - `state`: Image storage, quota management, chunked transfer state
+//! - `decode`: Payload decode pipeline (base64 → zlib → format → GraphicData)
+//! - `placement`: Image placement on the terminal grid, cropping, ID resolution
+//! - `response`: Protocol response formatting and PTY writing
+//!
+//! See: <https://sw.kovidgoyal.net/kitty/graphics-protocol/>
+
+pub mod decode;
+pub mod placement;
+pub mod response;
+pub mod state;
+
+use log::{debug, trace};
+
+use crate::event::EventListener;
+use crate::graphics::kitty_parser::{Action, DeleteTarget, KittyCommand};
+use crate::term::Term;
+
+pub use self::state::{KittyImage, KittyLoadingImage, KittyState};
+
+use self::decode::decode_payload;
+use self::placement::{place_image, resolve_image_id, resolve_or_assign_id};
+use self::response::{error_response, ok_response, send_response};
+
+/// Process a fully parsed kitty graphics command.
+///
+/// This is the main entry point called from `apc_end` in `term/mod.rs`.
+pub fn dispatch_command<L: EventListener>(term: &mut Term<L>, cmd: KittyCommand) {
+    // Handle chunked transfer accumulation.
+    if cmd.more_chunks {
+        handle_chunk_start(term, cmd);
+        return;
+    }
+
+    // Check if this is the final chunk of a multi-chunk transfer.
+    let cmd = if let Some(loading) = term.graphics.kitty_state.loading.take() {
+        finalize_chunked(loading, cmd)
+    } else {
+        cmd
+    };
+
+    let quiet = cmd.quiet;
+    let image_id = cmd.image_id;
+
+    match cmd.action {
+        Action::Transmit => {
+            let result = handle_transmit(term, &cmd);
+            send_response(term.event_proxy(), quiet, image_id, &result);
+        },
+        Action::TransmitAndDisplay => {
+            let result = handle_transmit_and_display(term, &cmd);
+            let resolved_id =
+                if image_id != 0 { image_id } else { cmd.image_number };
+            send_response(term.event_proxy(), quiet, resolved_id, &result);
+        },
+        Action::Query => {
+            handle_query(term, &cmd);
+        },
+        Action::Display => {
+            let result = handle_display(term, &cmd);
+            send_response(term.event_proxy(), quiet, image_id, &result);
+        },
+        Action::Delete => {
+            handle_delete(term, &cmd);
+        },
+        // Phase 3: Animation (stub).
+        Action::TransmitFrame => {
+            debug!("[kitty] TransmitFrame not yet implemented");
+            send_response(
+                term.event_proxy(),
+                quiet,
+                image_id,
+                &Err("animation frames not yet supported".into()),
+            );
+        },
+        Action::AnimationControl => {
+            debug!("[kitty] AnimationControl not yet implemented");
+        },
+        Action::ComposeFrames => {
+            debug!("[kitty] ComposeFrames not yet implemented");
+            send_response(
+                term.event_proxy(),
+                quiet,
+                image_id,
+                &Err("frame composition not yet supported".into()),
+            );
+        },
+    }
+}
+
+// ── Chunked Transfer ───────────────────────────────────────────────────
+
+/// Start or continue a chunked transfer (m=1).
+fn handle_chunk_start<L: EventListener>(term: &mut Term<L>, cmd: KittyCommand) {
+    let payload = cmd.payload.clone();
+
+    match &mut term.graphics.kitty_state.loading {
+        Some(loading) => {
+            loading.payload.extend_from_slice(&payload);
+            trace!(
+                "[kitty] chunk appended, total payload: {} bytes",
+                loading.payload.len()
+            );
+        },
+        None => {
+            trace!("[kitty] starting chunked transfer, first chunk: {} bytes", payload.len());
+            term.graphics.kitty_state.loading = Some(KittyLoadingImage {
+                command: cmd,
+                payload,
+            });
+        },
+    }
+}
+
+/// Finalize a chunked transfer by merging the last chunk.
+fn finalize_chunked(mut loading: KittyLoadingImage, final_cmd: KittyCommand) -> KittyCommand {
+    loading.payload.extend_from_slice(&final_cmd.payload);
+
+    let mut cmd = loading.command;
+    cmd.payload = loading.payload;
+    cmd.more_chunks = false;
+    cmd
+}
+
+// ── Action Handlers ────────────────────────────────────────────────────
+
+/// Handle `a=t` (transmit only, don't display).
+fn handle_transmit<L: EventListener>(
+    term: &mut Term<L>,
+    cmd: &KittyCommand,
+) -> Result<(), String> {
+    let graphic_data = decode_payload(cmd, &cmd.payload).map_err(|e| e.to_string())?;
+    let image_id = resolve_or_assign_id(term, cmd);
+    term.graphics.kitty_state.store_image(image_id, graphic_data);
+    debug!("[kitty] stored image id={image_id}");
+    Ok(())
+}
+
+/// Handle `a=T` (transmit and display).
+fn handle_transmit_and_display<L: EventListener>(
+    term: &mut Term<L>,
+    cmd: &KittyCommand,
+) -> Result<(), String> {
+    let graphic_data = decode_payload(cmd, &cmd.payload).map_err(|e| e.to_string())?;
+    let image_id = resolve_or_assign_id(term, cmd);
+
+    term.graphics.kitty_state.store_image(image_id, graphic_data);
+    debug!("[kitty] stored image id={image_id}, placing on grid");
+
+    place_image(term, image_id, cmd)
+}
+
+/// Handle `a=q` (query).
+fn handle_query<L: EventListener>(term: &mut Term<L>, cmd: &KittyCommand) {
+    use crate::event::Event;
+
+    let image_id = if cmd.image_id != 0 { cmd.image_id } else { 1 };
+
+    let result = if cmd.payload.is_empty() {
+        Ok(())
+    } else {
+        decode_payload(cmd, &cmd.payload).map(|_| ())
+    };
+
+    match result {
+        Ok(()) => {
+            let resp = ok_response(image_id);
+            trace!("[kitty] query response: {resp:?}");
+            term.event_proxy().send_event(Event::PtyWrite(resp));
+        },
+        Err(e) => {
+            let resp = error_response(image_id, "EINVAL", &e.to_string());
+            trace!("[kitty] query error response: {resp:?}");
+            term.event_proxy().send_event(Event::PtyWrite(resp));
+        },
+    }
+}
+
+/// Handle `a=p` (display a previously transmitted image).
+fn handle_display<L: EventListener>(
+    term: &mut Term<L>,
+    cmd: &KittyCommand,
+) -> Result<(), String> {
+    let image_id = resolve_image_id(&term.graphics.kitty_state, cmd)
+        .ok_or_else(|| "image not found".to_string())?;
+
+    if !term.graphics.kitty_state.images.contains_key(&image_id) {
+        return Err(format!("image id={image_id} not found in storage"));
+    }
+
+    place_image(term, image_id, cmd)
+}
+
+/// Handle `a=d` (delete).
+fn handle_delete<L: EventListener>(term: &mut Term<L>, cmd: &KittyCommand) {
+    let target = cmd.delete.unwrap_or(DeleteTarget::All);
+    debug!("[kitty] delete: {target:?}, image_id={}, image_number={}", cmd.image_id, cmd.image_number);
+    term.graphics.kitty_state.delete(target, cmd);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graphics::kitty_parser::{Action, Format};
+
+    #[test]
+    fn finalize_chunked_merges_payloads() {
+        let loading = KittyLoadingImage {
+            command: KittyCommand {
+                action: Action::TransmitAndDisplay,
+                format: Format::Png,
+                image_id: 5,
+                ..Default::default()
+            },
+            payload: b"AAAA".to_vec(),
+        };
+
+        let final_cmd = KittyCommand {
+            payload: b"BBBB".to_vec(),
+            ..Default::default()
+        };
+
+        let merged = finalize_chunked(loading, final_cmd);
+        assert_eq!(merged.action, Action::TransmitAndDisplay);
+        assert_eq!(merged.format, Format::Png);
+        assert_eq!(merged.image_id, 5);
+        assert_eq!(merged.payload, b"AAAABBBB");
+        assert!(!merged.more_chunks);
+    }
+}

--- a/alacritty_terminal/src/graphics/kitty/placement.rs
+++ b/alacritty_terminal/src/graphics/kitty/placement.rs
@@ -35,6 +35,24 @@ pub fn place_image<L: EventListener>(
         )
     };
 
+    // Scale the image if columns/rows are specified.
+    let (pixels, width, height) = if cmd.columns > 0 || cmd.rows > 0 {
+        let params = ScaleParams {
+            color_type,
+            columns: cmd.columns,
+            rows: cmd.rows,
+            cell_width: term.graphics.cell_width as usize,
+            cell_height: term.graphics.cell_height as usize,
+        };
+        scale_image(&pixels, width, height, &params)?
+    } else {
+        (pixels, width, height)
+    };
+
+    // Apply sub-cell pixel offsets via transparent padding.
+    let (pixels, width, height, color_type) =
+        apply_pixel_offsets(pixels, width, height, color_type, cmd.offset_x, cmd.offset_y);
+
     let graphic_id = term.graphics.next_id();
 
     let graphic = GraphicData {
@@ -60,6 +78,163 @@ pub fn place_image<L: EventListener>(
     }
 
     Ok(())
+}
+
+/// Calculate target dimensions for cell-based scaling.
+///
+/// Returns `(target_width, target_height)` in pixels.
+pub fn calculate_scaled_dimensions(
+    src_w: usize,
+    src_h: usize,
+    columns: u32,
+    rows: u32,
+    cell_width: usize,
+    cell_height: usize,
+) -> (usize, usize) {
+    match (columns > 0, rows > 0) {
+        (true, true) => {
+            // Both specified: exact target size.
+            let tw = columns as usize * cell_width;
+            let th = rows as usize * cell_height;
+            (tw, th)
+        },
+        (true, false) => {
+            // Only columns: scale height proportionally.
+            let tw = columns as usize * cell_width;
+            let th = (src_h * tw).checked_div(src_w).unwrap_or(src_h);
+            (tw, th)
+        },
+        (false, true) => {
+            // Only rows: scale width proportionally.
+            let th = rows as usize * cell_height;
+            let tw = (src_w * th).checked_div(src_h).unwrap_or(src_w);
+            (tw, th)
+        },
+        (false, false) => {
+            // No scaling requested.
+            (src_w, src_h)
+        },
+    }
+}
+
+/// Parameters for cell-based image scaling.
+pub struct ScaleParams {
+    /// Source image color type.
+    pub color_type: ColorType,
+    /// Display columns (`c=`).
+    pub columns: u32,
+    /// Display rows (`r=`).
+    pub rows: u32,
+    /// Terminal cell width in pixels.
+    pub cell_width: usize,
+    /// Terminal cell height in pixels.
+    pub cell_height: usize,
+}
+
+/// Scale image pixel data to the target dimensions derived from columns/rows.
+///
+/// Uses bilinear (Triangle) filtering via the `image` crate.
+pub fn scale_image(
+    pixels: &[u8],
+    src_w: usize,
+    src_h: usize,
+    params: &ScaleParams,
+) -> Result<(Vec<u8>, usize, usize), String> {
+    let (target_w, target_h) = calculate_scaled_dimensions(
+        src_w,
+        src_h,
+        params.columns,
+        params.rows,
+        params.cell_width,
+        params.cell_height,
+    );
+
+    if target_w == 0 || target_h == 0 {
+        return Err("scaled dimensions are zero".into());
+    }
+
+    // If the dimensions haven't changed, skip the resize.
+    if target_w == src_w && target_h == src_h {
+        return Ok((pixels.to_vec(), src_w, src_h));
+    }
+
+    // Convert to RGBA for the image crate.
+    let rgba_pixels = match params.color_type {
+        ColorType::Rgba => pixels.to_vec(),
+        ColorType::Rgb => rgb_to_rgba(pixels),
+    };
+
+    let src_image = image::RgbaImage::from_raw(src_w as u32, src_h as u32, rgba_pixels)
+        .ok_or_else(|| {
+            format!(
+                "failed to create image buffer from {src_w}x{src_h} ({} bytes)",
+                pixels.len()
+            )
+        })?;
+
+    let resized = image::imageops::resize(
+        &src_image,
+        target_w as u32,
+        target_h as u32,
+        image::imageops::FilterType::Triangle,
+    );
+
+    // Always output RGBA after scaling (the resize may introduce alpha even
+    // on originally-RGB images due to filtering at edges).
+    Ok((resized.into_raw(), target_w, target_h))
+}
+
+/// Apply sub-cell pixel offsets by padding the image with transparent pixels.
+///
+/// If both offsets are zero, the data is returned unchanged (possibly
+/// promoting RGB → RGBA when offsets are applied).
+pub fn apply_pixel_offsets(
+    pixels: Vec<u8>,
+    width: usize,
+    height: usize,
+    color_type: ColorType,
+    offset_x: u32,
+    offset_y: u32,
+) -> (Vec<u8>, usize, usize, ColorType) {
+    let ox = offset_x as usize;
+    let oy = offset_y as usize;
+
+    if ox == 0 && oy == 0 {
+        return (pixels, width, height, color_type);
+    }
+
+    let new_w = width + ox;
+    let new_h = height + oy;
+    let new_stride = new_w * 4;
+
+    // We need RGBA to have transparent padding.
+    let rgba_pixels = match color_type {
+        ColorType::Rgba => pixels,
+        ColorType::Rgb => rgb_to_rgba(&pixels),
+    };
+
+    let src_stride = width * 4;
+    let mut out = vec![0u8; new_h * new_stride];
+
+    for row in 0..height {
+        let src_start = row * src_stride;
+        let dst_start = (row + oy) * new_stride + ox * 4;
+        out[dst_start..dst_start + src_stride]
+            .copy_from_slice(&rgba_pixels[src_start..src_start + src_stride]);
+    }
+
+    (out, new_w, new_h, ColorType::Rgba)
+}
+
+/// Convert RGB pixel data to RGBA (fully opaque).
+fn rgb_to_rgba(rgb: &[u8]) -> Vec<u8> {
+    let pixel_count = rgb.len() / 3;
+    let mut rgba = Vec::with_capacity(pixel_count * 4);
+    for chunk in rgb.chunks_exact(3) {
+        rgba.extend_from_slice(chunk);
+        rgba.push(255);
+    }
+    rgba
 }
 
 /// Crop an image according to source rectangle parameters.
@@ -132,17 +307,265 @@ pub fn resolve_image_id(state: &KittyState, cmd: &KittyCommand) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::graphics::{GraphicId, ColorType};
+    use crate::graphics::GraphicId;
+
+    // ---------------------------------------------------------------
+    // Dimension calculation tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn scale_dimensions_both_set() {
+        let (tw, th) = calculate_scaled_dimensions(100, 200, 5, 3, 8, 16);
+        assert_eq!(tw, 40); // 5 * 8
+        assert_eq!(th, 48); // 3 * 16
+    }
+
+    #[test]
+    fn scale_dimensions_only_columns() {
+        // 100×200, columns=5, cell_width=8 → tw=40, th = 200*40/100 = 80
+        let (tw, th) = calculate_scaled_dimensions(100, 200, 5, 0, 8, 16);
+        assert_eq!(tw, 40);
+        assert_eq!(th, 80);
+    }
+
+    #[test]
+    fn scale_dimensions_only_rows() {
+        // 100×200, rows=4, cell_height=16 → th=64, tw = 100*64/200 = 32
+        let (tw, th) = calculate_scaled_dimensions(100, 200, 0, 4, 8, 16);
+        assert_eq!(tw, 32);
+        assert_eq!(th, 64);
+    }
+
+    #[test]
+    fn scale_dimensions_none() {
+        let (tw, th) = calculate_scaled_dimensions(100, 200, 0, 0, 8, 16);
+        assert_eq!(tw, 100);
+        assert_eq!(th, 200);
+    }
+
+    #[test]
+    fn scale_dimensions_square_proportional() {
+        // 64×64, columns=4, cell_width=10 → tw=40, th=64*40/64=40
+        let (tw, th) = calculate_scaled_dimensions(64, 64, 4, 0, 10, 10);
+        assert_eq!(tw, 40);
+        assert_eq!(th, 40);
+    }
+
+    // ---------------------------------------------------------------
+    // Pixel scaling tests
+    // ---------------------------------------------------------------
+
+    fn make_scale_params(color_type: ColorType, columns: u32, rows: u32, cw: usize, ch: usize) -> ScaleParams {
+        ScaleParams { color_type, columns, rows, cell_width: cw, cell_height: ch }
+    }
+
+    #[test]
+    fn scale_image_upscale() {
+        // 4×4 solid red RGBA → scale to 8×8
+        let red = [255u8, 0, 0, 255];
+        let pixels: Vec<u8> = red.repeat(4 * 4);
+        let params = make_scale_params(ColorType::Rgba, 1, 1, 8, 8);
+        let (out, w, h) = scale_image(&pixels, 4, 4, &params).unwrap();
+        assert_eq!(w, 8);
+        assert_eq!(h, 8);
+        assert_eq!(out.len(), 8 * 8 * 4);
+        // All pixels should still be red (solid color scales perfectly).
+        for chunk in out.chunks_exact(4) {
+            assert_eq!(chunk, &red);
+        }
+    }
+
+    #[test]
+    fn scale_image_downscale() {
+        // 8×8 solid green → scale to 4×4
+        let green = [0u8, 255, 0, 255];
+        let pixels: Vec<u8> = green.repeat(8 * 8);
+        let params = make_scale_params(ColorType::Rgba, 2, 2, 2, 2);
+        let (out, w, h) = scale_image(&pixels, 8, 8, &params).unwrap();
+        assert_eq!(w, 4);
+        assert_eq!(h, 4);
+        assert_eq!(out.len(), 4 * 4 * 4);
+    }
+
+    #[test]
+    fn scale_image_noop_when_same_size() {
+        let pixels: Vec<u8> = vec![128; 4 * 4 * 4];
+        let params = make_scale_params(ColorType::Rgba, 2, 2, 2, 2);
+        let (out, w, h) = scale_image(&pixels, 4, 4, &params).unwrap();
+        assert_eq!(w, 4);
+        assert_eq!(h, 4);
+        assert_eq!(out, pixels);
+    }
+
+    #[test]
+    fn scale_image_rgb_input() {
+        // Ensure RGB input is handled (promoted to RGBA for scaling).
+        let blue = [0u8, 0, 255];
+        let pixels: Vec<u8> = blue.repeat(4 * 4);
+        let params = make_scale_params(ColorType::Rgb, 1, 1, 8, 8);
+        let (out, w, h) = scale_image(&pixels, 4, 4, &params).unwrap();
+        assert_eq!(w, 8);
+        assert_eq!(h, 8);
+        // Output is RGBA (4 bytes per pixel).
+        assert_eq!(out.len(), 8 * 8 * 4);
+    }
+
+    #[test]
+    fn scale_image_zero_target_errors() {
+        let pixels: Vec<u8> = vec![0; 16];
+        // columns=1 but cell_width=0 → target 0.
+        let params = make_scale_params(ColorType::Rgba, 1, 0, 0, 16);
+        let result = scale_image(&pixels, 2, 2, &params);
+        assert!(result.is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // Crop + scale interaction
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn crop_then_scale() {
+        // 8×8 image, crop to 4×4, then scale to 2 columns × 2 rows at 4×4 cell → 8×8.
+        let pixels: Vec<u8> = vec![100; 8 * 8 * 4];
+        let src = GraphicData {
+            id: GraphicId(0),
+            width: 8,
+            height: 8,
+            color_type: ColorType::Rgba,
+            pixels,
+            is_opaque: false,
+        };
+        let cmd = KittyCommand {
+            src_x: 2,
+            src_y: 2,
+            src_w: 4,
+            src_h: 4,
+            ..Default::default()
+        };
+        let (cropped, cw, ch, ct) = crop_image(&src, &cmd).unwrap();
+        assert_eq!((cw, ch), (4, 4));
+
+        let params = make_scale_params(ct, 2, 2, 4, 4);
+        let (scaled, sw, sh) = scale_image(&cropped, cw, ch, &params).unwrap();
+        assert_eq!(sw, 8);
+        assert_eq!(sh, 8);
+        assert_eq!(scaled.len(), 8 * 8 * 4);
+    }
+
+    // ---------------------------------------------------------------
+    // Pixel offset (padding) tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn offset_no_op() {
+        let pixels = vec![255u8; 2 * 2 * 4];
+        let (out, w, h, ct) = apply_pixel_offsets(pixels.clone(), 2, 2, ColorType::Rgba, 0, 0);
+        assert_eq!(w, 2);
+        assert_eq!(h, 2);
+        assert_eq!(ct, ColorType::Rgba);
+        assert_eq!(out, pixels);
+    }
+
+    #[test]
+    fn offset_x_only() {
+        // 2×2 white RGBA, offset_x=3 → 5×2 with 3-pixel transparent left strip.
+        let white = [255u8, 255, 255, 255];
+        let pixels: Vec<u8> = white.repeat(2 * 2);
+        let (out, w, h, ct) = apply_pixel_offsets(pixels, 2, 2, ColorType::Rgba, 3, 0);
+        assert_eq!(w, 5);
+        assert_eq!(h, 2);
+        assert_eq!(ct, ColorType::Rgba);
+        assert_eq!(out.len(), 5 * 2 * 4);
+
+        // First 3 pixels of row 0 should be transparent (all zeroes).
+        for px in 0..3 {
+            let start = px * 4;
+            assert_eq!(&out[start..start + 4], &[0, 0, 0, 0]);
+        }
+        // Pixel at (3,0) should be white.
+        assert_eq!(&out[12..16], &white);
+    }
+
+    #[test]
+    fn offset_y_only() {
+        // 2×2 red RGBA, offset_y=2 → 2×4 with 2 transparent rows on top.
+        let red = [255u8, 0, 0, 255];
+        let pixels: Vec<u8> = red.repeat(2 * 2);
+        let (out, w, h, ct) = apply_pixel_offsets(pixels, 2, 2, ColorType::Rgba, 0, 2);
+        assert_eq!(w, 2);
+        assert_eq!(h, 4);
+        assert_eq!(ct, ColorType::Rgba);
+
+        // First 2 rows (2*2*4 = 16 bytes) should be all zeroes.
+        assert!(out[..16].iter().all(|&b| b == 0));
+        // Row 2, pixel 0 should be red.
+        assert_eq!(&out[16..20], &red);
+    }
+
+    #[test]
+    fn offset_both() {
+        let blue = [0u8, 0, 255, 255];
+        let pixels: Vec<u8> = blue.repeat(1); // 1×1 image
+        let (out, w, h, ct) = apply_pixel_offsets(pixels, 1, 1, ColorType::Rgba, 2, 3);
+        assert_eq!(w, 3);
+        assert_eq!(h, 4);
+        assert_eq!(ct, ColorType::Rgba);
+
+        // Only pixel at (2, 3) should be blue; everything else transparent.
+        for row in 0..h {
+            for col in 0..w {
+                let start = (row * w + col) * 4;
+                if row == 3 && col == 2 {
+                    assert_eq!(&out[start..start + 4], &blue);
+                } else {
+                    assert_eq!(&out[start..start + 4], &[0, 0, 0, 0]);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn offset_promotes_rgb_to_rgba() {
+        let pixels = vec![128u8; 2 * 2 * 3]; // RGB
+        let (out, w, h, ct) = apply_pixel_offsets(pixels, 2, 2, ColorType::Rgb, 1, 0);
+        assert_eq!(w, 3);
+        assert_eq!(h, 2);
+        assert_eq!(ct, ColorType::Rgba);
+        assert_eq!(out.len(), 3 * 2 * 4);
+    }
+
+    // ---------------------------------------------------------------
+    // rgb_to_rgba helper
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn rgb_to_rgba_conversion() {
+        let rgb = vec![10, 20, 30, 40, 50, 60];
+        let rgba = rgb_to_rgba(&rgb);
+        assert_eq!(rgba, vec![10, 20, 30, 255, 40, 50, 60, 255]);
+    }
+
+    // ---------------------------------------------------------------
+    // Existing crop tests (must keep passing)
+    // ---------------------------------------------------------------
 
     #[test]
     fn crop_image_basic() {
         let pixels: Vec<u8> = [255, 0, 0, 255].repeat(16);
         let src = GraphicData {
-            id: GraphicId(0), width: 4, height: 4,
-            color_type: ColorType::Rgba, pixels, is_opaque: false,
+            id: GraphicId(0),
+            width: 4,
+            height: 4,
+            color_type: ColorType::Rgba,
+            pixels,
+            is_opaque: false,
         };
         let cmd = KittyCommand {
-            src_x: 1, src_y: 1, src_w: 2, src_h: 2, ..Default::default()
+            src_x: 1,
+            src_y: 1,
+            src_w: 2,
+            src_h: 2,
+            ..Default::default()
         };
         let (cropped, w, h, ct) = crop_image(&src, &cmd).unwrap();
         assert_eq!(w, 2);
@@ -154,11 +577,19 @@ mod tests {
     #[test]
     fn crop_image_out_of_bounds() {
         let src = GraphicData {
-            id: GraphicId(0), width: 4, height: 4,
-            color_type: ColorType::Rgba, pixels: vec![0; 64], is_opaque: false,
+            id: GraphicId(0),
+            width: 4,
+            height: 4,
+            color_type: ColorType::Rgba,
+            pixels: vec![0; 64],
+            is_opaque: false,
         };
         let cmd = KittyCommand {
-            src_x: 3, src_y: 3, src_w: 3, src_h: 3, ..Default::default()
+            src_x: 3,
+            src_y: 3,
+            src_w: 3,
+            src_h: 3,
+            ..Default::default()
         };
         assert!(crop_image(&src, &cmd).is_err());
     }

--- a/alacritty_terminal/src/graphics/kitty/placement.rs
+++ b/alacritty_terminal/src/graphics/kitty/placement.rs
@@ -1,0 +1,165 @@
+//! Kitty graphics image placement and ID resolution.
+
+use crate::event::EventListener;
+use crate::graphics::kitty::state::KittyState;
+use crate::graphics::kitty_parser::KittyCommand;
+use crate::graphics::{ColorType, GraphicData};
+use crate::term::Term;
+
+/// Place an image on the terminal grid.
+pub fn place_image<L: EventListener>(
+    term: &mut Term<L>,
+    image_id: u32,
+    cmd: &KittyCommand,
+) -> Result<(), String> {
+    let stored = term
+        .graphics
+        .kitty_state
+        .get_image(image_id)
+        .ok_or_else(|| format!("image id={image_id} not in storage"))?;
+
+    let src_data = &stored.data;
+
+    let (pixels, width, height, color_type) = if cmd.src_x != 0
+        || cmd.src_y != 0
+        || (cmd.src_w != 0 && cmd.src_w != src_data.width as u32)
+        || (cmd.src_h != 0 && cmd.src_h != src_data.height as u32)
+    {
+        crop_image(src_data, cmd)?
+    } else {
+        (
+            src_data.pixels.clone(),
+            src_data.width,
+            src_data.height,
+            src_data.color_type,
+        )
+    };
+
+    let graphic_id = term.graphics.next_id();
+
+    let graphic = GraphicData {
+        id: graphic_id,
+        width,
+        height,
+        color_type,
+        pixels,
+        is_opaque: color_type == ColorType::Rgb,
+    };
+
+    let no_cursor_move = cmd.cursor_movement == 1;
+    let saved_cursor = if no_cursor_move {
+        Some(term.grid().cursor.point)
+    } else {
+        None
+    };
+
+    crate::graphics::insert_graphic(term, graphic, None);
+
+    if let Some(point) = saved_cursor {
+        term.grid_mut().cursor.point = point;
+    }
+
+    Ok(())
+}
+
+/// Crop an image according to source rectangle parameters.
+pub fn crop_image(
+    src: &GraphicData,
+    cmd: &KittyCommand,
+) -> Result<(Vec<u8>, usize, usize, ColorType), String> {
+    let bpp = match src.color_type {
+        ColorType::Rgba => 4,
+        ColorType::Rgb => 3,
+    };
+
+    let sx = cmd.src_x as usize;
+    let sy = cmd.src_y as usize;
+    let sw = if cmd.src_w == 0 { src.width - sx } else { cmd.src_w as usize };
+    let sh = if cmd.src_h == 0 { src.height - sy } else { cmd.src_h as usize };
+
+    if sx + sw > src.width || sy + sh > src.height {
+        return Err(format!(
+            "source rect ({sx},{sy},{sw},{sh}) exceeds image ({}x{})",
+            src.width, src.height
+        ));
+    }
+
+    if sw == 0 || sh == 0 {
+        return Err("source rect has zero width or height".into());
+    }
+
+    let src_stride = src.width * bpp;
+    let dst_stride = sw * bpp;
+    let mut cropped = Vec::with_capacity(sh * dst_stride);
+
+    for row in sy..sy + sh {
+        let src_start = row * src_stride + sx * bpp;
+        let src_end = src_start + dst_stride;
+        cropped.extend_from_slice(&src.pixels[src_start..src_end]);
+    }
+
+    Ok((cropped, sw, sh, src.color_type))
+}
+
+/// Resolve or auto-assign an image ID for a transmit command.
+pub fn resolve_or_assign_id<L: EventListener>(term: &mut Term<L>, cmd: &KittyCommand) -> u32 {
+    let state = &mut term.graphics.kitty_state;
+
+    let image_id = if cmd.image_id != 0 {
+        cmd.image_id
+    } else {
+        state.next_id()
+    };
+
+    if cmd.image_number != 0 {
+        state.number_to_id.insert(cmd.image_number, image_id);
+    }
+
+    image_id
+}
+
+/// Resolve an image ID from a command, checking both `i=` and `I=`.
+pub fn resolve_image_id(state: &KittyState, cmd: &KittyCommand) -> Option<u32> {
+    if cmd.image_id != 0 {
+        Some(cmd.image_id)
+    } else if cmd.image_number != 0 {
+        state.resolve_number(cmd.image_number)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graphics::{GraphicId, ColorType};
+
+    #[test]
+    fn crop_image_basic() {
+        let pixels: Vec<u8> = [255, 0, 0, 255].repeat(16);
+        let src = GraphicData {
+            id: GraphicId(0), width: 4, height: 4,
+            color_type: ColorType::Rgba, pixels, is_opaque: false,
+        };
+        let cmd = KittyCommand {
+            src_x: 1, src_y: 1, src_w: 2, src_h: 2, ..Default::default()
+        };
+        let (cropped, w, h, ct) = crop_image(&src, &cmd).unwrap();
+        assert_eq!(w, 2);
+        assert_eq!(h, 2);
+        assert_eq!(ct, ColorType::Rgba);
+        assert_eq!(cropped.len(), 2 * 2 * 4);
+    }
+
+    #[test]
+    fn crop_image_out_of_bounds() {
+        let src = GraphicData {
+            id: GraphicId(0), width: 4, height: 4,
+            color_type: ColorType::Rgba, pixels: vec![0; 64], is_opaque: false,
+        };
+        let cmd = KittyCommand {
+            src_x: 3, src_y: 3, src_w: 3, src_h: 3, ..Default::default()
+        };
+        assert!(crop_image(&src, &cmd).is_err());
+    }
+}

--- a/alacritty_terminal/src/graphics/kitty/response.rs
+++ b/alacritty_terminal/src/graphics/kitty/response.rs
@@ -1,0 +1,59 @@
+//! Kitty graphics protocol response formatting and sending.
+
+use log::trace;
+
+use crate::event::{Event, EventListener};
+use crate::graphics::kitty_parser::Quiet;
+
+/// Build a kitty graphics OK response.
+pub fn ok_response(image_id: u32) -> String {
+    format!("\x1b_Gi={image_id};OK\x1b\\")
+}
+
+/// Build a kitty graphics error response.
+pub fn error_response(image_id: u32, code: &str, message: &str) -> String {
+    format!("\x1b_Gi={image_id};{code}:{message}\x1b\\")
+}
+
+/// Send a response to the PTY, respecting quiet mode.
+pub fn send_response<L: EventListener>(
+    event_proxy: &L,
+    quiet: Quiet,
+    image_id: u32,
+    result: &Result<(), String>,
+) {
+    match result {
+        Ok(()) => {
+            if quiet == Quiet::None {
+                let resp = ok_response(image_id);
+                trace!("[kitty] response: {resp:?}");
+                event_proxy.send_event(Event::PtyWrite(resp));
+            }
+        },
+        Err(msg) => {
+            if quiet != Quiet::SuppressAll {
+                let resp = error_response(image_id, "EINVAL", msg);
+                trace!("[kitty] response: {resp:?}");
+                event_proxy.send_event(Event::PtyWrite(resp));
+            }
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ok_response_format() {
+        assert_eq!(ok_response(42), "\x1b_Gi=42;OK\x1b\\");
+    }
+
+    #[test]
+    fn error_response_format() {
+        assert_eq!(
+            error_response(42, "EINVAL", "bad image"),
+            "\x1b_Gi=42;EINVAL:bad image\x1b\\"
+        );
+    }
+}

--- a/alacritty_terminal/src/graphics/kitty/response.rs
+++ b/alacritty_terminal/src/graphics/kitty/response.rs
@@ -16,12 +16,23 @@ pub fn error_response(image_id: u32, code: &str, message: &str) -> String {
 }
 
 /// Send a response to the PTY, respecting quiet mode.
+///
+/// Per the kitty spec (and matching kitty's `finish_command_response`):
+/// no response is sent when both image ID and image number are 0
+/// (i.e. the client didn't specify `i=` or `I=`). The caller passes
+/// the resolved ID (which is 0 when neither was set).
 pub fn send_response<L: EventListener>(
     event_proxy: &L,
     quiet: Quiet,
     image_id: u32,
     result: &Result<(), String>,
 ) {
+    // Kitty: "if (g->id || g->image_number) { ... } return NULL;"
+    // No response when the client didn't request one via id/number.
+    if image_id == 0 {
+        return;
+    }
+
     match result {
         Ok(()) => {
             if quiet == Quiet::None {

--- a/alacritty_terminal/src/graphics/kitty/state.rs
+++ b/alacritty_terminal/src/graphics/kitty/state.rs
@@ -1,0 +1,212 @@
+//! Kitty graphics image storage and state management.
+
+use std::collections::HashMap;
+
+use log::debug;
+
+use crate::graphics::kitty_parser::{DeleteTarget, KittyCommand};
+use crate::graphics::GraphicData;
+
+/// Maximum total memory for kitty image storage (320 MiB).
+const STORAGE_QUOTA: usize = 320 * 1024 * 1024;
+
+/// A stored kitty image, potentially with multiple placements on screen.
+#[derive(Debug)]
+pub struct KittyImage {
+    /// The decoded pixel data. Retained for re-placement and animation.
+    pub data: GraphicData,
+    /// Size of the pixel data in bytes (for quota tracking).
+    pub total_bytes: usize,
+}
+
+/// Accumulator for chunked image transfers.
+#[derive(Debug)]
+pub struct KittyLoadingImage {
+    /// The command from the first chunk (carries format, medium, etc.).
+    pub command: KittyCommand,
+    /// Accumulated raw base64 payload bytes across chunks.
+    pub payload: Vec<u8>,
+}
+
+/// Kitty graphics protocol state, stored inside `Graphics`.
+#[derive(Debug, Default)]
+pub struct KittyState {
+    /// Stored images keyed by image ID.
+    pub images: HashMap<u32, KittyImage>,
+    /// Mapping from image number (`I=`) to image ID (`i=`).
+    pub number_to_id: HashMap<u32, u32>,
+    /// Image currently being loaded via chunked transfer.
+    pub loading: Option<KittyLoadingImage>,
+    /// Total bytes used by stored images (for quota enforcement).
+    pub used_memory: usize,
+    /// Next auto-assigned image ID (when client doesn't provide one).
+    next_image_id: u32,
+}
+
+impl KittyState {
+    /// Allocate a new unique image ID.
+    pub fn next_id(&mut self) -> u32 {
+        self.next_image_id = self.next_image_id.wrapping_add(1);
+        if self.next_image_id == 0 {
+            self.next_image_id = 1;
+        }
+        self.next_image_id
+    }
+
+    /// Evict unreferenced images until we're under the storage quota.
+    pub fn enforce_quota(&mut self) {
+        if self.used_memory <= STORAGE_QUOTA {
+            return;
+        }
+
+        let target_free = self.used_memory - STORAGE_QUOTA;
+        let mut freed = 0usize;
+
+        let ids_to_remove: Vec<u32> = self
+            .images
+            .iter()
+            .filter_map(|(&id, img)| {
+                if freed < target_free {
+                    freed += img.total_bytes;
+                    Some(id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for id in ids_to_remove {
+            if let Some(img) = self.images.remove(&id) {
+                self.used_memory = self.used_memory.saturating_sub(img.total_bytes);
+            }
+        }
+
+        self.number_to_id.retain(|_, img_id| self.images.contains_key(img_id));
+    }
+
+    /// Store an image. Enforces quota before inserting.
+    pub fn store_image(&mut self, image_id: u32, data: GraphicData) -> u32 {
+        let total_bytes = data.pixels.len();
+
+        if let Some(old) = self.images.remove(&image_id) {
+            self.used_memory = self.used_memory.saturating_sub(old.total_bytes);
+        }
+
+        self.used_memory += total_bytes;
+        self.enforce_quota();
+
+        self.images.insert(image_id, KittyImage { data, total_bytes });
+
+        image_id
+    }
+
+    /// Look up an image by ID.
+    pub fn get_image(&self, image_id: u32) -> Option<&KittyImage> {
+        self.images.get(&image_id)
+    }
+
+    /// Resolve an image number to an image ID, if mapped.
+    pub fn resolve_number(&self, image_number: u32) -> Option<u32> {
+        self.number_to_id.get(&image_number).copied()
+    }
+
+    /// Delete images according to the given target.
+    pub fn delete(&mut self, target: DeleteTarget, cmd: &KittyCommand) {
+        match target {
+            DeleteTarget::All | DeleteTarget::AllIncludingScrollback => {
+                self.used_memory = 0;
+                self.images.clear();
+                self.number_to_id.clear();
+            },
+            DeleteTarget::ById | DeleteTarget::ByIdIncludingScrollback => {
+                if cmd.image_id != 0 {
+                    if let Some(img) = self.images.remove(&cmd.image_id) {
+                        self.used_memory = self.used_memory.saturating_sub(img.total_bytes);
+                    }
+                    self.number_to_id.retain(|_, &mut id| id != cmd.image_id);
+                }
+            },
+            DeleteTarget::ByNumber | DeleteTarget::ByNumberIncludingScrollback => {
+                if cmd.image_number != 0 {
+                    if let Some(image_id) = self.number_to_id.remove(&cmd.image_number) {
+                        if let Some(img) = self.images.remove(&image_id) {
+                            self.used_memory = self.used_memory.saturating_sub(img.total_bytes);
+                        }
+                    }
+                }
+            },
+            _ => {
+                debug!("[kitty] unimplemented delete target: {target:?}");
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graphics::{ColorType, GraphicId};
+
+    fn make_graphic(size: usize) -> GraphicData {
+        GraphicData {
+            id: GraphicId(0),
+            width: 1,
+            height: 1,
+            color_type: ColorType::Rgba,
+            pixels: vec![0; size],
+            is_opaque: false,
+        }
+    }
+
+    #[test]
+    fn store_and_retrieve() {
+        let mut state = KittyState::default();
+        state.store_image(42, make_graphic(16));
+        assert!(state.get_image(42).is_some());
+        assert_eq!(state.used_memory, 16);
+    }
+
+    #[test]
+    fn number_to_id() {
+        let mut state = KittyState::default();
+        state.number_to_id.insert(100, 42);
+        assert_eq!(state.resolve_number(100), Some(42));
+        assert_eq!(state.resolve_number(999), None);
+    }
+
+    #[test]
+    fn delete_by_id() {
+        let mut state = KittyState::default();
+        state.store_image(10, make_graphic(4));
+        assert!(state.get_image(10).is_some());
+
+        let cmd = KittyCommand { image_id: 10, ..Default::default() };
+        state.delete(DeleteTarget::ById, &cmd);
+        assert!(state.get_image(10).is_none());
+        assert_eq!(state.used_memory, 0);
+    }
+
+    #[test]
+    fn delete_all() {
+        let mut state = KittyState::default();
+        for id in 1..=5 {
+            state.store_image(id, make_graphic(4));
+        }
+        assert_eq!(state.images.len(), 5);
+
+        let cmd = KittyCommand::default();
+        state.delete(DeleteTarget::All, &cmd);
+        assert!(state.images.is_empty());
+        assert_eq!(state.used_memory, 0);
+    }
+
+    #[test]
+    fn auto_id() {
+        let mut state = KittyState::default();
+        let id1 = state.next_id();
+        let id2 = state.next_id();
+        assert_ne!(id1, id2);
+        assert_ne!(id1, 0);
+        assert_ne!(id2, 0);
+    }
+}

--- a/alacritty_terminal/src/graphics/kitty/state.rs
+++ b/alacritty_terminal/src/graphics/kitty/state.rs
@@ -1,9 +1,10 @@
 //! Kitty graphics image storage and state management.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use log::debug;
 
+
+use super::animation::AnimationState;
 use crate::graphics::kitty_parser::{DeleteTarget, KittyCommand};
 use crate::graphics::GraphicData;
 
@@ -24,8 +25,52 @@ pub struct KittyImage {
 pub struct KittyLoadingImage {
     /// The command from the first chunk (carries format, medium, etc.).
     pub command: KittyCommand,
-    /// Accumulated raw base64 payload bytes across chunks.
-    pub payload: Vec<u8>,
+    /// Accumulated decoded bytes across chunks.
+    ///
+    /// Each chunk's base64 is decoded on arrival and the raw bytes are
+    /// appended here. This handles clients that independently base64-encode
+    /// each chunk (e.g. chafa), which would corrupt group alignment if we
+    /// concatenated base64 strings and decoded once at the end.
+    pub data: Vec<u8>,
+}
+
+/// A tracked kitty image placement on the terminal grid.
+///
+/// Coordinates are 0-based, matching the internal grid coordinate system.
+/// The `row` field is `i32` to represent scrollback (negative values).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KittyPlacement {
+    /// Image ID this placement refers to.
+    pub image_id: u32,
+    /// Placement ID (0 = unspecified / default).
+    pub placement_id: u32,
+    /// Column where the top-left corner is placed (0-based).
+    pub col: usize,
+    /// Row where the top-left corner is placed (0-based, negative for scrollback).
+    pub row: i32,
+    /// Number of columns the placement spans.
+    pub width: usize,
+    /// Number of rows the placement spans.
+    pub height: usize,
+    /// Z-index for layering.
+    pub z_index: i32,
+}
+
+impl KittyPlacement {
+    /// Check whether this placement overlaps the given column.
+    fn overlaps_col(&self, col: usize) -> bool {
+        col >= self.col && col < self.col + self.width
+    }
+
+    /// Check whether this placement overlaps the given row.
+    fn overlaps_row(&self, row: i32) -> bool {
+        row >= self.row && row < self.row + self.height as i32
+    }
+
+    /// Check whether this placement overlaps the given cell.
+    fn overlaps_cell(&self, col: usize, row: i32) -> bool {
+        self.overlaps_col(col) && self.overlaps_row(row)
+    }
 }
 
 /// Kitty graphics protocol state, stored inside `Graphics`.
@@ -35,10 +80,14 @@ pub struct KittyState {
     pub images: HashMap<u32, KittyImage>,
     /// Mapping from image number (`I=`) to image ID (`i=`).
     pub number_to_id: HashMap<u32, u32>,
+    /// Animation states keyed by image ID.
+    pub animation_states: HashMap<u32, AnimationState>,
     /// Image currently being loaded via chunked transfer.
     pub loading: Option<KittyLoadingImage>,
     /// Total bytes used by stored images (for quota enforcement).
     pub used_memory: usize,
+    /// Tracked placements on the terminal grid.
+    pub placements: Vec<KittyPlacement>,
     /// Next auto-assigned image ID (when client doesn't provide one).
     next_image_id: u32,
 }
@@ -110,33 +159,214 @@ impl KittyState {
         self.number_to_id.get(&image_number).copied()
     }
 
-    /// Delete images according to the given target.
-    pub fn delete(&mut self, target: DeleteTarget, cmd: &KittyCommand) {
+    /// Register a placement on the grid.
+    ///
+    /// This should be called from `placement.rs`'s `place_image()` after the
+    /// image has been placed on the grid. Coordinates are 0-based.
+    pub fn register_placement(&mut self, placement: KittyPlacement) {
+        self.placements.push(placement);
+    }
+
+    /// Remove placements matching a predicate, returning the set of image IDs
+    /// that had at least one placement removed.
+    fn remove_placements_matching<F>(&mut self, predicate: F) -> HashSet<u32>
+    where
+        F: Fn(&KittyPlacement) -> bool,
+    {
+        let mut removed_image_ids = HashSet::new();
+        self.placements.retain(|p| {
+            if predicate(p) {
+                removed_image_ids.insert(p.image_id);
+                false
+            } else {
+                true
+            }
+        });
+        removed_image_ids
+    }
+
+    /// Remove images whose IDs are in `ids` and that are no longer referenced
+    /// by any remaining placement. Also cleans up `number_to_id` mappings.
+    fn remove_orphaned_images(&mut self, ids: &HashSet<u32>) {
+        for &id in ids {
+            let still_referenced = self.placements.iter().any(|p| p.image_id == id);
+            if !still_referenced {
+                if let Some(img) = self.images.remove(&id) {
+                    self.used_memory = self.used_memory.saturating_sub(img.total_bytes);
+                }
+                self.number_to_id.retain(|_, img_id| *img_id != id);
+                self.animation_states.remove(&id);
+            }
+        }
+    }
+
+    /// Resolve a 1-based column value from the kitty protocol to 0-based,
+    /// falling back to `cursor_col` when the value is 0 (not specified).
+    fn resolve_col(src_x: u32, cursor_col: usize) -> usize {
+        if src_x > 0 { (src_x - 1) as usize } else { cursor_col }
+    }
+
+    /// Resolve a 1-based row value from the kitty protocol to 0-based,
+    /// falling back to `cursor_row` when the value is 0 (not specified).
+    fn resolve_row(src_y: u32, cursor_row: usize) -> i32 {
+        if src_y > 0 { src_y as i32 - 1 } else { cursor_row as i32 }
+    }
+
+    /// Look up an animation state by image ID.
+    pub fn get_animation(&self, image_id: u32) -> Option<&AnimationState> {
+        self.animation_states.get(&image_id)
+    }
+
+    /// Look up a mutable animation state by image ID.
+    pub fn get_animation_mut(&mut self, image_id: u32) -> Option<&mut AnimationState> {
+        self.animation_states.get_mut(&image_id)
+    }
+
+    /// Delete images and/or placements according to the given target.
+    ///
+    /// `cursor_col` and `cursor_row` are 0-based grid coordinates of the
+    /// terminal cursor, used for cursor-relative and fallback positioning.
+    pub fn delete(
+        &mut self,
+        target: DeleteTarget,
+        cmd: &KittyCommand,
+        cursor_col: usize,
+        cursor_row: usize,
+    ) {
         match target {
+            // ── All ────────────────────────────────────────────────────
             DeleteTarget::All | DeleteTarget::AllIncludingScrollback => {
                 self.used_memory = 0;
                 self.images.clear();
                 self.number_to_id.clear();
+                self.placements.clear();
+                self.animation_states.clear();
             },
+
+            // ── By image ID ───────────────────────────────────────────
             DeleteTarget::ById | DeleteTarget::ByIdIncludingScrollback => {
                 if cmd.image_id != 0 {
+                    self.placements.retain(|p| p.image_id != cmd.image_id);
                     if let Some(img) = self.images.remove(&cmd.image_id) {
                         self.used_memory = self.used_memory.saturating_sub(img.total_bytes);
                     }
                     self.number_to_id.retain(|_, &mut id| id != cmd.image_id);
+                    self.animation_states.remove(&cmd.image_id);
                 }
             },
+
+            // ── By image number ───────────────────────────────────────
             DeleteTarget::ByNumber | DeleteTarget::ByNumberIncludingScrollback => {
                 if cmd.image_number != 0 {
                     if let Some(image_id) = self.number_to_id.remove(&cmd.image_number) {
+                        self.placements.retain(|p| p.image_id != image_id);
                         if let Some(img) = self.images.remove(&image_id) {
                             self.used_memory = self.used_memory.saturating_sub(img.total_bytes);
                         }
+                        self.animation_states.remove(&image_id);
                     }
                 }
             },
-            _ => {
-                debug!("[kitty] unimplemented delete target: {target:?}");
+
+            // ── At cursor position ────────────────────────────────────
+            DeleteTarget::AtCursor => {
+                let col = cursor_col;
+                let row = cursor_row as i32;
+                self.remove_placements_matching(|p| p.overlaps_cell(col, row));
+            },
+            DeleteTarget::AtCursorIncludingScrollback => {
+                let col = cursor_col;
+                let row = cursor_row as i32;
+                let removed = self.remove_placements_matching(|p| p.overlaps_cell(col, row));
+                self.remove_orphaned_images(&removed);
+            },
+
+            // ── By placement ID ───────────────────────────────────────
+            DeleteTarget::ByPlacementId => {
+                self.remove_placements_matching(|p| {
+                    p.placement_id == cmd.placement_id
+                        && (cmd.image_id == 0 || p.image_id == cmd.image_id)
+                });
+            },
+            DeleteTarget::ByPlacementIdIncludingScrollback => {
+                let removed = self.remove_placements_matching(|p| {
+                    p.placement_id == cmd.placement_id
+                        && (cmd.image_id == 0 || p.image_id == cmd.image_id)
+                });
+                self.remove_orphaned_images(&removed);
+            },
+
+            // ── By column ─────────────────────────────────────────────
+            DeleteTarget::ByColumn => {
+                let col = Self::resolve_col(cmd.src_x, cursor_col);
+                self.remove_placements_matching(|p| p.overlaps_col(col));
+            },
+            DeleteTarget::ByColumnIncludingScrollback => {
+                let col = Self::resolve_col(cmd.src_x, cursor_col);
+                let removed = self.remove_placements_matching(|p| p.overlaps_col(col));
+                self.remove_orphaned_images(&removed);
+            },
+
+            // ── By row ────────────────────────────────────────────────
+            DeleteTarget::ByRow => {
+                let row = Self::resolve_row(cmd.src_y, cursor_row);
+                self.remove_placements_matching(|p| p.overlaps_row(row));
+            },
+            DeleteTarget::ByRowIncludingScrollback => {
+                let row = Self::resolve_row(cmd.src_y, cursor_row);
+                let removed = self.remove_placements_matching(|p| p.overlaps_row(row));
+                self.remove_orphaned_images(&removed);
+            },
+
+            // ── By cell position ──────────────────────────────────────
+            DeleteTarget::ByCell => {
+                let col = Self::resolve_col(cmd.src_x, cursor_col);
+                let row = Self::resolve_row(cmd.src_y, cursor_row);
+                self.remove_placements_matching(|p| p.overlaps_cell(col, row));
+            },
+            DeleteTarget::ByCellIncludingScrollback => {
+                let col = Self::resolve_col(cmd.src_x, cursor_col);
+                let row = Self::resolve_row(cmd.src_y, cursor_row);
+                let removed = self.remove_placements_matching(|p| p.overlaps_cell(col, row));
+                self.remove_orphaned_images(&removed);
+            },
+
+            // ── By cell position + z-index ────────────────────────────
+            DeleteTarget::ByCellZ => {
+                let col = Self::resolve_col(cmd.src_x, cursor_col);
+                let row = Self::resolve_row(cmd.src_y, cursor_row);
+                let z = cmd.z_index;
+                self.remove_placements_matching(|p| {
+                    p.overlaps_cell(col, row) && p.z_index == z
+                });
+            },
+            DeleteTarget::ByCellZIncludingScrollback => {
+                let col = Self::resolve_col(cmd.src_x, cursor_col);
+                let row = Self::resolve_row(cmd.src_y, cursor_row);
+                let z = cmd.z_index;
+                let removed = self.remove_placements_matching(|p| {
+                    p.overlaps_cell(col, row) && p.z_index == z
+                });
+                self.remove_orphaned_images(&removed);
+            },
+
+            // ── By z-index ────────────────────────────────────────────
+            DeleteTarget::ByZIndex => {
+                let z = cmd.z_index;
+                self.remove_placements_matching(|p| p.z_index == z);
+            },
+            DeleteTarget::ByZIndexIncludingScrollback => {
+                let z = cmd.z_index;
+                let removed = self.remove_placements_matching(|p| p.z_index == z);
+                self.remove_orphaned_images(&removed);
+            },
+
+            // ── Animation frames ──────────────────────────────────────
+            DeleteTarget::AnimationFrames
+            | DeleteTarget::AnimationFramesIncludingScrollback => {
+                if cmd.image_id != 0 {
+                    self.animation_states.remove(&cmd.image_id);
+                }
             },
         }
     }
@@ -158,6 +388,51 @@ mod tests {
         }
     }
 
+    fn default_cmd() -> KittyCommand {
+        KittyCommand::default()
+    }
+
+    /// Build a state with known images and placements for testing.
+    ///
+    /// Layout (0-based grid coordinates):
+    ///
+    /// - Image 1, placement 10: col=0, row=0, 3×2, z=0
+    /// - Image 1, placement 11: col=5, row=5, 2×2, z=1
+    /// - Image 2, placement 20: col=2, row=1, 4×3, z=0
+    /// - Image 3, placement 30: col=8, row=0, 1×1, z=-1
+    /// - Image 3, placement 31: col=0, row=4, 10×1, z=2
+    fn make_test_state() -> KittyState {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(16));
+        state.store_image(2, make_graphic(32));
+        state.store_image(3, make_graphic(8));
+
+        state.number_to_id.insert(100, 1);
+        state.number_to_id.insert(200, 2);
+
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 10, col: 0, row: 0, width: 3, height: 2, z_index: 0,
+        });
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 11, col: 5, row: 5, width: 2, height: 2, z_index: 1,
+        });
+        state.register_placement(KittyPlacement {
+            image_id: 2, placement_id: 20, col: 2, row: 1, width: 4, height: 3, z_index: 0,
+        });
+        state.register_placement(KittyPlacement {
+            image_id: 3, placement_id: 30, col: 8, row: 0, width: 1, height: 1, z_index: -1,
+        });
+        state.register_placement(KittyPlacement {
+            image_id: 3, placement_id: 31, col: 0, row: 4, width: 10, height: 1, z_index: 2,
+        });
+
+        assert_eq!(state.placements.len(), 5);
+        assert_eq!(state.images.len(), 3);
+        state
+    }
+
+    // ── Existing tests (updated signatures) ────────────────────────────
+
     #[test]
     fn store_and_retrieve() {
         let mut state = KittyState::default();
@@ -178,12 +453,16 @@ mod tests {
     fn delete_by_id() {
         let mut state = KittyState::default();
         state.store_image(10, make_graphic(4));
+        state.register_placement(KittyPlacement {
+            image_id: 10, placement_id: 1, col: 0, row: 0, width: 1, height: 1, z_index: 0,
+        });
         assert!(state.get_image(10).is_some());
 
-        let cmd = KittyCommand { image_id: 10, ..Default::default() };
-        state.delete(DeleteTarget::ById, &cmd);
+        let cmd = KittyCommand { image_id: 10, ..default_cmd() };
+        state.delete(DeleteTarget::ById, &cmd, 0, 0);
         assert!(state.get_image(10).is_none());
         assert_eq!(state.used_memory, 0);
+        assert!(state.placements.is_empty());
     }
 
     #[test]
@@ -191,12 +470,17 @@ mod tests {
         let mut state = KittyState::default();
         for id in 1..=5 {
             state.store_image(id, make_graphic(4));
+            state.register_placement(KittyPlacement {
+                image_id: id, placement_id: id, col: 0, row: 0, width: 1, height: 1, z_index: 0,
+            });
         }
         assert_eq!(state.images.len(), 5);
+        assert_eq!(state.placements.len(), 5);
 
-        let cmd = KittyCommand::default();
-        state.delete(DeleteTarget::All, &cmd);
+        let cmd = default_cmd();
+        state.delete(DeleteTarget::All, &cmd, 0, 0);
         assert!(state.images.is_empty());
+        assert!(state.placements.is_empty());
         assert_eq!(state.used_memory, 0);
     }
 
@@ -208,5 +492,571 @@ mod tests {
         assert_ne!(id1, id2);
         assert_ne!(id1, 0);
         assert_ne!(id2, 0);
+    }
+
+    // ── Placement registration ─────────────────────────────────────────
+
+    #[test]
+    fn register_placement_records_correctly() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(4));
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 42, col: 3, row: 5, width: 2, height: 4, z_index: -1,
+        });
+
+        assert_eq!(state.placements.len(), 1);
+        let p = &state.placements[0];
+        assert_eq!(p.image_id, 1);
+        assert_eq!(p.placement_id, 42);
+        assert_eq!(p.col, 3);
+        assert_eq!(p.row, 5);
+        assert_eq!(p.width, 2);
+        assert_eq!(p.height, 4);
+        assert_eq!(p.z_index, -1);
+    }
+
+    // ── Overlap helpers ────────────────────────────────────────────────
+
+    #[test]
+    fn placement_overlap_col() {
+        let p = KittyPlacement {
+            image_id: 1, placement_id: 0, col: 2, row: 0, width: 3, height: 1, z_index: 0,
+        };
+        assert!(!p.overlaps_col(1));
+        assert!(p.overlaps_col(2));
+        assert!(p.overlaps_col(3));
+        assert!(p.overlaps_col(4));
+        assert!(!p.overlaps_col(5));
+    }
+
+    #[test]
+    fn placement_overlap_row() {
+        let p = KittyPlacement {
+            image_id: 1, placement_id: 0, col: 0, row: 3, width: 1, height: 2, z_index: 0,
+        };
+        assert!(!p.overlaps_row(2));
+        assert!(p.overlaps_row(3));
+        assert!(p.overlaps_row(4));
+        assert!(!p.overlaps_row(5));
+    }
+
+    #[test]
+    fn placement_overlap_cell() {
+        let p = KittyPlacement {
+            image_id: 1, placement_id: 0, col: 1, row: 1, width: 3, height: 2, z_index: 0,
+        };
+        assert!(p.overlaps_cell(2, 2));
+        assert!(!p.overlaps_cell(0, 0));
+        assert!(!p.overlaps_cell(4, 1));
+        assert!(!p.overlaps_cell(1, 3));
+    }
+
+    // ── Delete at cursor ───────────────────────────────────────────────
+
+    #[test]
+    fn delete_at_cursor() {
+        let mut state = make_test_state();
+
+        // Cursor at (1, 1) overlaps placement 10 (0..3, 0..2) and 20 (2..6, 1..4).
+        let cmd = default_cmd();
+        state.delete(DeleteTarget::AtCursor, &cmd, 1, 1);
+
+        // Placement 10 covers col 0..3, row 0..2 → (1,1) is inside.
+        // Placement 20 covers col 2..6, row 1..4 → (1,1) col=1 < 2, NOT inside.
+        // So only placement 10 is removed.
+        assert_eq!(state.placements.len(), 4);
+        assert!(!state.placements.iter().any(|p| p.placement_id == 10));
+        // Images should still be present (non-scrollback variant).
+        assert!(state.get_image(1).is_some());
+    }
+
+    #[test]
+    fn delete_at_cursor_including_scrollback_orphans_image() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(16));
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 10, col: 0, row: 0, width: 2, height: 2, z_index: 0,
+        });
+
+        let cmd = default_cmd();
+        state.delete(DeleteTarget::AtCursorIncludingScrollback, &cmd, 0, 0);
+
+        assert!(state.placements.is_empty());
+        // Image 1 is now orphaned and should be removed.
+        assert!(state.get_image(1).is_none());
+        assert_eq!(state.used_memory, 0);
+    }
+
+    #[test]
+    fn delete_at_cursor_scrollback_keeps_shared_image() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(16));
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 10, col: 0, row: 0, width: 2, height: 2, z_index: 0,
+        });
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 11, col: 5, row: 5, width: 1, height: 1, z_index: 0,
+        });
+
+        // Cursor at (0, 0) hits placement 10 but not 11.
+        let cmd = default_cmd();
+        state.delete(DeleteTarget::AtCursorIncludingScrollback, &cmd, 0, 0);
+
+        assert_eq!(state.placements.len(), 1);
+        assert_eq!(state.placements[0].placement_id, 11);
+        // Image 1 still referenced by placement 11, so kept.
+        assert!(state.get_image(1).is_some());
+    }
+
+    // ── Delete by placement ID ─────────────────────────────────────────
+
+    #[test]
+    fn delete_by_placement_id() {
+        let mut state = make_test_state();
+
+        let cmd = KittyCommand { placement_id: 20, ..default_cmd() };
+        state.delete(DeleteTarget::ByPlacementId, &cmd, 0, 0);
+
+        assert_eq!(state.placements.len(), 4);
+        assert!(!state.placements.iter().any(|p| p.placement_id == 20));
+        // Image 2 still in storage (non-scrollback).
+        assert!(state.get_image(2).is_some());
+    }
+
+    #[test]
+    fn delete_by_placement_id_with_image_id_filter() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(4));
+        state.store_image(2, make_graphic(4));
+        // Two placements with the same placement_id but different image_ids.
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 99, col: 0, row: 0, width: 1, height: 1, z_index: 0,
+        });
+        state.register_placement(KittyPlacement {
+            image_id: 2, placement_id: 99, col: 1, row: 0, width: 1, height: 1, z_index: 0,
+        });
+
+        // Delete placement_id=99 with image_id=1 — should only remove the first.
+        let cmd = KittyCommand { placement_id: 99, image_id: 1, ..default_cmd() };
+        state.delete(DeleteTarget::ByPlacementId, &cmd, 0, 0);
+
+        assert_eq!(state.placements.len(), 1);
+        assert_eq!(state.placements[0].image_id, 2);
+    }
+
+    #[test]
+    fn delete_by_placement_id_scrollback_removes_orphan() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(8));
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 50, col: 0, row: 0, width: 1, height: 1, z_index: 0,
+        });
+
+        let cmd = KittyCommand { placement_id: 50, ..default_cmd() };
+        state.delete(DeleteTarget::ByPlacementIdIncludingScrollback, &cmd, 0, 0);
+
+        assert!(state.placements.is_empty());
+        assert!(state.get_image(1).is_none());
+        assert_eq!(state.used_memory, 0);
+    }
+
+    // ── Delete by z-index ──────────────────────────────────────────────
+
+    #[test]
+    fn delete_by_z_index() {
+        let mut state = make_test_state();
+
+        // z=0: placements 10 and 20.
+        let cmd = KittyCommand { z_index: 0, ..default_cmd() };
+        state.delete(DeleteTarget::ByZIndex, &cmd, 0, 0);
+
+        assert_eq!(state.placements.len(), 3);
+        assert!(!state.placements.iter().any(|p| p.z_index == 0));
+        // Images still present (non-scrollback).
+        assert!(state.get_image(1).is_some());
+        assert!(state.get_image(2).is_some());
+    }
+
+    #[test]
+    fn delete_by_z_index_scrollback() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(4));
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 10, col: 0, row: 0, width: 1, height: 1, z_index: 5,
+        });
+
+        let cmd = KittyCommand { z_index: 5, ..default_cmd() };
+        state.delete(DeleteTarget::ByZIndexIncludingScrollback, &cmd, 0, 0);
+
+        assert!(state.placements.is_empty());
+        assert!(state.get_image(1).is_none());
+        assert_eq!(state.used_memory, 0);
+    }
+
+    #[test]
+    fn delete_by_z_index_no_match() {
+        let mut state = make_test_state();
+        let before = state.placements.len();
+
+        let cmd = KittyCommand { z_index: 999, ..default_cmd() };
+        state.delete(DeleteTarget::ByZIndex, &cmd, 0, 0);
+
+        assert_eq!(state.placements.len(), before);
+    }
+
+    // ── Delete by column ───────────────────────────────────────────────
+
+    #[test]
+    fn delete_by_column() {
+        let mut state = make_test_state();
+
+        // Column 9 (1-based src_x=10) — only placement 31 (col 0..10) overlaps col 9.
+        // Placement 30 is at col=8 width=1, so it covers col 8 only.
+        let cmd = KittyCommand { src_x: 10, ..default_cmd() };
+        state.delete(DeleteTarget::ByColumn, &cmd, 0, 0);
+
+        assert_eq!(state.placements.len(), 4);
+        assert!(!state.placements.iter().any(|p| p.placement_id == 31));
+    }
+
+    #[test]
+    fn delete_by_column_spanning() {
+        let mut state = make_test_state();
+
+        // Column 3 (1-based src_x=4) — overlaps:
+        //   placement 20 (col 2..6) ✓
+        //   placement 31 (col 0..10) ✓
+        // Does NOT overlap:
+        //   placement 10 (col 0..3) — col 3 is NOT < 0+3=3 ✗
+        //   placement 11 (col 5..7) ✗
+        //   placement 30 (col 8..9) ✗
+        let cmd = KittyCommand { src_x: 4, ..default_cmd() };
+        state.delete(DeleteTarget::ByColumn, &cmd, 0, 0);
+
+        assert_eq!(state.placements.len(), 3);
+        let remaining_ids: Vec<u32> =
+            state.placements.iter().map(|p| p.placement_id).collect();
+        assert!(remaining_ids.contains(&10));
+        assert!(remaining_ids.contains(&11));
+        assert!(remaining_ids.contains(&30));
+    }
+
+    #[test]
+    fn delete_by_column_scrollback_orphans() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(4));
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 10, col: 3, row: 0, width: 2, height: 1, z_index: 0,
+        });
+
+        // Column 4 (1-based src_x=5) hits placement at col 3..5.
+        let cmd = KittyCommand { src_x: 5, ..default_cmd() };
+        state.delete(DeleteTarget::ByColumnIncludingScrollback, &cmd, 0, 0);
+
+        assert!(state.placements.is_empty());
+        assert!(state.get_image(1).is_none());
+    }
+
+    #[test]
+    fn delete_by_column_fallback_to_cursor() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(4));
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 10, col: 5, row: 0, width: 2, height: 1, z_index: 0,
+        });
+
+        // src_x=0 means "use cursor column". Cursor at col=6.
+        let cmd = default_cmd();
+        state.delete(DeleteTarget::ByColumn, &cmd, 6, 0);
+
+        assert!(state.placements.is_empty());
+    }
+
+    // ── Delete by row ──────────────────────────────────────────────────
+
+    #[test]
+    fn delete_by_row() {
+        let mut state = make_test_state();
+
+        // Row 0 (1-based src_y=1) — overlaps:
+        //   placement 10 (row 0..2) ✓
+        //   placement 30 (row 0..1) ✓
+        let cmd = KittyCommand { src_y: 1, ..default_cmd() };
+        state.delete(DeleteTarget::ByRow, &cmd, 0, 0);
+
+        assert_eq!(state.placements.len(), 3);
+        assert!(!state.placements.iter().any(|p| p.placement_id == 10));
+        assert!(!state.placements.iter().any(|p| p.placement_id == 30));
+    }
+
+    #[test]
+    fn delete_by_row_scrollback_orphans() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(4));
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 10, col: 0, row: 2, width: 1, height: 3, z_index: 0,
+        });
+
+        // Row 3 (1-based src_y=4) hits placement at row 2..5.
+        let cmd = KittyCommand { src_y: 4, ..default_cmd() };
+        state.delete(DeleteTarget::ByRowIncludingScrollback, &cmd, 0, 0);
+
+        assert!(state.placements.is_empty());
+        assert!(state.get_image(1).is_none());
+    }
+
+    #[test]
+    fn delete_by_row_fallback_to_cursor() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(4));
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 10, col: 0, row: 3, width: 1, height: 2, z_index: 0,
+        });
+
+        // src_y=0 means "use cursor row". Cursor at row=4.
+        let cmd = default_cmd();
+        state.delete(DeleteTarget::ByRow, &cmd, 0, 4);
+
+        assert!(state.placements.is_empty());
+    }
+
+    // ── Delete by cell ─────────────────────────────────────────────────
+
+    #[test]
+    fn delete_by_cell() {
+        let mut state = make_test_state();
+
+        // Cell (3, 2) in 1-based: src_x=4, src_y=3. Overlaps:
+        //   placement 20 (col 2..6, row 1..4) ✓
+        let cmd = KittyCommand { src_x: 4, src_y: 3, ..default_cmd() };
+        state.delete(DeleteTarget::ByCell, &cmd, 0, 0);
+
+        assert_eq!(state.placements.len(), 4);
+        assert!(!state.placements.iter().any(|p| p.placement_id == 20));
+    }
+
+    #[test]
+    fn delete_by_cell_scrollback_orphans() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(4));
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 10, col: 0, row: 0, width: 2, height: 2, z_index: 0,
+        });
+
+        let cmd = KittyCommand { src_x: 1, src_y: 1, ..default_cmd() };
+        state.delete(DeleteTarget::ByCellIncludingScrollback, &cmd, 0, 0);
+
+        assert!(state.placements.is_empty());
+        assert!(state.get_image(1).is_none());
+    }
+
+    #[test]
+    fn delete_by_cell_fallback_to_cursor() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(4));
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 10, col: 3, row: 4, width: 2, height: 2, z_index: 0,
+        });
+
+        // Both src_x=0, src_y=0 → use cursor at (4, 5).
+        let cmd = default_cmd();
+        state.delete(DeleteTarget::ByCell, &cmd, 4, 5);
+
+        assert!(state.placements.is_empty());
+    }
+
+    // ── Delete by cell + z-index ───────────────────────────────────────
+
+    #[test]
+    fn delete_by_cell_z() {
+        let mut state = make_test_state();
+
+        // Cell (5, 5) with z=1. Placement 11 is at (5, 5) 2×2 z=1 → match.
+        // Placement 31 is at (0, 4) 10×1 z=2 → overlaps col 5, row 4 only, row 5 not covered.
+        let cmd = KittyCommand { src_x: 6, src_y: 6, z_index: 1, ..default_cmd() };
+        state.delete(DeleteTarget::ByCellZ, &cmd, 0, 0);
+
+        assert_eq!(state.placements.len(), 4);
+        assert!(!state.placements.iter().any(|p| p.placement_id == 11));
+    }
+
+    #[test]
+    fn delete_by_cell_z_wrong_z_no_match() {
+        let mut state = make_test_state();
+
+        // Cell (5, 5) with z=999 — no placement has z=999 at that cell.
+        let cmd = KittyCommand { src_x: 6, src_y: 6, z_index: 999, ..default_cmd() };
+        state.delete(DeleteTarget::ByCellZ, &cmd, 0, 0);
+
+        assert_eq!(state.placements.len(), 5);
+    }
+
+    #[test]
+    fn delete_by_cell_z_scrollback_orphans() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(4));
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 10, col: 0, row: 0, width: 2, height: 2, z_index: 7,
+        });
+
+        let cmd = KittyCommand { src_x: 1, src_y: 1, z_index: 7, ..default_cmd() };
+        state.delete(DeleteTarget::ByCellZIncludingScrollback, &cmd, 0, 0);
+
+        assert!(state.placements.is_empty());
+        assert!(state.get_image(1).is_none());
+    }
+
+    // ── Delete by number ───────────────────────────────────────────────
+
+    #[test]
+    fn delete_by_number() {
+        let mut state = make_test_state();
+
+        let cmd = KittyCommand { image_number: 100, ..default_cmd() };
+        state.delete(DeleteTarget::ByNumber, &cmd, 0, 0);
+
+        // Image number 100 → image ID 1. Placements 10 and 11 reference image 1.
+        assert!(!state.placements.iter().any(|p| p.image_id == 1));
+        assert!(state.get_image(1).is_none());
+        // Other images untouched.
+        assert!(state.get_image(2).is_some());
+        assert!(state.get_image(3).is_some());
+    }
+
+    // ── Delete all including scrollback ────────────────────────────────
+
+    #[test]
+    fn delete_all_including_scrollback() {
+        let mut state = make_test_state();
+
+        let cmd = default_cmd();
+        state.delete(DeleteTarget::AllIncludingScrollback, &cmd, 0, 0);
+
+        assert!(state.images.is_empty());
+        assert!(state.placements.is_empty());
+        assert!(state.number_to_id.is_empty());
+        assert_eq!(state.used_memory, 0);
+    }
+
+    // ── IncludingScrollback preserves images still referenced ──────────
+
+    #[test]
+    fn scrollback_preserves_images_with_remaining_placements() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(16));
+        state.store_image(2, make_graphic(8));
+
+        // Two placements for image 1 at different z-indices.
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 10, col: 0, row: 0, width: 1, height: 1, z_index: 0,
+        });
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 11, col: 2, row: 2, width: 1, height: 1, z_index: 5,
+        });
+        // One placement for image 2 at z=0.
+        state.register_placement(KittyPlacement {
+            image_id: 2, placement_id: 20, col: 1, row: 1, width: 1, height: 1, z_index: 0,
+        });
+
+        // Delete z=0 with scrollback — removes placements 10 and 20.
+        let cmd = KittyCommand { z_index: 0, ..default_cmd() };
+        state.delete(DeleteTarget::ByZIndexIncludingScrollback, &cmd, 0, 0);
+
+        assert_eq!(state.placements.len(), 1);
+        assert_eq!(state.placements[0].placement_id, 11);
+
+        // Image 1 still referenced by placement 11 → kept.
+        assert!(state.get_image(1).is_some());
+        // Image 2 orphaned → removed.
+        assert!(state.get_image(2).is_none());
+        assert_eq!(state.used_memory, 16);
+    }
+
+    // ── Animation frames stub ──────────────────────────────────────────
+
+    #[test]
+    fn delete_animation_frames_is_noop() {
+        let mut state = make_test_state();
+        let before = state.placements.len();
+
+        let cmd = default_cmd();
+        state.delete(DeleteTarget::AnimationFrames, &cmd, 0, 0);
+        assert_eq!(state.placements.len(), before);
+
+        state.delete(DeleteTarget::AnimationFramesIncludingScrollback, &cmd, 0, 0);
+        assert_eq!(state.placements.len(), before);
+    }
+
+    // ── Edge cases ─────────────────────────────────────────────────────
+
+    #[test]
+    fn delete_with_no_placements_is_harmless() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(4));
+
+        let cmd = default_cmd();
+        state.delete(DeleteTarget::AtCursor, &cmd, 5, 5);
+        assert!(state.get_image(1).is_some());
+        assert_eq!(state.used_memory, 4);
+    }
+
+    #[test]
+    fn delete_by_id_also_removes_placements() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(4));
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 10, col: 0, row: 0, width: 1, height: 1, z_index: 0,
+        });
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 11, col: 1, row: 1, width: 1, height: 1, z_index: 0,
+        });
+
+        let cmd = KittyCommand { image_id: 1, ..default_cmd() };
+        state.delete(DeleteTarget::ByIdIncludingScrollback, &cmd, 0, 0);
+
+        assert!(state.placements.is_empty());
+        assert!(state.get_image(1).is_none());
+    }
+
+    #[test]
+    fn delete_by_id_zero_is_noop() {
+        let mut state = make_test_state();
+        let before_placements = state.placements.len();
+        let before_images = state.images.len();
+
+        let cmd = KittyCommand { image_id: 0, ..default_cmd() };
+        state.delete(DeleteTarget::ById, &cmd, 0, 0);
+
+        assert_eq!(state.placements.len(), before_placements);
+        assert_eq!(state.images.len(), before_images);
+    }
+
+    #[test]
+    fn negative_row_placement_not_hit_by_positive_cursor() {
+        let mut state = KittyState::default();
+        state.store_image(1, make_graphic(4));
+        // Placement in scrollback (negative row).
+        state.register_placement(KittyPlacement {
+            image_id: 1, placement_id: 10, col: 0, row: -5, width: 3, height: 2, z_index: 0,
+        });
+
+        // Cursor at row 0 — should not overlap a placement at row -5..-3.
+        let cmd = default_cmd();
+        state.delete(DeleteTarget::AtCursor, &cmd, 0, 0);
+
+        assert_eq!(state.placements.len(), 1);
+    }
+
+    #[test]
+    fn resolve_col_and_row_helpers() {
+        // 1-based → 0-based conversion.
+        assert_eq!(KittyState::resolve_col(5, 99), 4);
+        assert_eq!(KittyState::resolve_col(1, 99), 0);
+        // 0 → cursor fallback.
+        assert_eq!(KittyState::resolve_col(0, 7), 7);
+
+        assert_eq!(KittyState::resolve_row(5, 99), 4);
+        assert_eq!(KittyState::resolve_row(1, 99), 0);
+        assert_eq!(KittyState::resolve_row(0, 7), 7);
     }
 }

--- a/alacritty_terminal/src/graphics/kitty_parser.rs
+++ b/alacritty_terminal/src/graphics/kitty_parser.rs
@@ -1,0 +1,798 @@
+//! Kitty graphics protocol parser.
+//!
+//! Parses the key=value format used in kitty graphics APC sequences.
+//! See: https://sw.kovidgoyal.net/kitty/graphics-protocol/
+
+use log::debug;
+
+/// Action type for the kitty graphics command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    /// `a=t` — Transmit image data (default).
+    Transmit,
+    /// `a=T` — Transmit and display.
+    TransmitAndDisplay,
+    /// `a=q` — Query terminal support.
+    Query,
+    /// `a=p` — Display a previously transmitted image.
+    Display,
+    /// `a=d` — Delete images/placements.
+    Delete,
+    /// `a=f` — Transmit animation frame.
+    TransmitFrame,
+    /// `a=a` — Control animation.
+    AnimationControl,
+    /// `a=c` — Compose animation frames.
+    ComposeFrames,
+}
+
+impl Action {
+    fn from_byte(b: u8) -> Option<Self> {
+        match b {
+            b't' => Some(Action::Transmit),
+            b'T' => Some(Action::TransmitAndDisplay),
+            b'q' => Some(Action::Query),
+            b'p' => Some(Action::Display),
+            b'd' => Some(Action::Delete),
+            b'f' => Some(Action::TransmitFrame),
+            b'a' => Some(Action::AnimationControl),
+            b'c' => Some(Action::ComposeFrames),
+            _ => None,
+        }
+    }
+}
+
+/// Image data format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    /// `f=24` — 24-bit RGB.
+    Rgb,
+    /// `f=32` — 32-bit RGBA (default).
+    Rgba,
+    /// `f=100` — PNG.
+    Png,
+}
+
+impl Format {
+    fn from_u32(v: u32) -> Option<Self> {
+        match v {
+            24 => Some(Format::Rgb),
+            32 => Some(Format::Rgba),
+            100 => Some(Format::Png),
+            _ => None,
+        }
+    }
+}
+
+/// Transmission medium.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Medium {
+    /// `t=d` — Direct (inline base64, default).
+    Direct,
+    /// `t=f` — Regular file.
+    File,
+    /// `t=t` — Temporary file.
+    TempFile,
+    /// `t=s` — Shared memory.
+    SharedMemory,
+}
+
+impl Medium {
+    fn from_byte(b: u8) -> Option<Self> {
+        match b {
+            b'd' => Some(Medium::Direct),
+            b'f' => Some(Medium::File),
+            b't' => Some(Medium::TempFile),
+            b's' => Some(Medium::SharedMemory),
+            _ => None,
+        }
+    }
+}
+
+/// Compression type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Compression {
+    /// No compression.
+    None,
+    /// `o=z` — zlib/deflate.
+    Zlib,
+}
+
+impl Compression {
+    fn from_byte(b: u8) -> Option<Self> {
+        match b {
+            b'z' => Some(Compression::Zlib),
+            _ => None,
+        }
+    }
+}
+
+/// Quiet mode for response suppression.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Quiet {
+    /// `q=0` — Send all responses (default).
+    None,
+    /// `q=1` — Suppress OK responses.
+    SuppressOk,
+    /// `q=2` — Suppress all responses.
+    SuppressAll,
+}
+
+impl Quiet {
+    fn from_u32(v: u32) -> Option<Self> {
+        match v {
+            0 => Some(Quiet::None),
+            1 => Some(Quiet::SuppressOk),
+            2 => Some(Quiet::SuppressAll),
+            _ => None,
+        }
+    }
+}
+
+/// Delete target for `a=d` commands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeleteTarget {
+    /// `d=a` — All visible placements.
+    All,
+    /// `d=A` — All placements (visible and in scrollback).
+    AllIncludingScrollback,
+    /// `d=i` — By image ID (visible).
+    ById,
+    /// `d=I` — By image ID (including scrollback).
+    ByIdIncludingScrollback,
+    /// `d=n` — By image number (visible).
+    ByNumber,
+    /// `d=N` — By image number (including scrollback).
+    ByNumberIncludingScrollback,
+    /// `d=c` — At cursor position (visible).
+    AtCursor,
+    /// `d=C` — At cursor position (including scrollback).
+    AtCursorIncludingScrollback,
+    /// `d=f` — Animation frames by image ID.
+    AnimationFrames,
+    /// `d=F` — Animation frames by image ID (including scrollback).
+    AnimationFramesIncludingScrollback,
+    /// `d=p` — By placement ID (visible).
+    ByPlacementId,
+    /// `d=P` — By placement ID (including scrollback).
+    ByPlacementIdIncludingScrollback,
+    /// `d=q` — By column range (visible).
+    ByColumn,
+    /// `d=Q` — By column range (including scrollback).
+    ByColumnIncludingScrollback,
+    /// `d=r` — By row range (visible).
+    ByRow,
+    /// `d=R` — By row range (including scrollback).
+    ByRowIncludingScrollback,
+    /// `d=x` — By cell position (visible).
+    ByCell,
+    /// `d=X` — By cell position (including scrollback).
+    ByCellIncludingScrollback,
+    /// `d=y` — By cell position with z-index (visible).
+    ByCellZ,
+    /// `d=Y` — By cell position with z-index (including scrollback).
+    ByCellZIncludingScrollback,
+    /// `d=z` — By z-index (visible).
+    ByZIndex,
+    /// `d=Z` — By z-index (including scrollback).
+    ByZIndexIncludingScrollback,
+}
+
+impl DeleteTarget {
+    fn from_byte(b: u8) -> Option<Self> {
+        match b {
+            b'a' => Some(DeleteTarget::All),
+            b'A' => Some(DeleteTarget::AllIncludingScrollback),
+            b'i' => Some(DeleteTarget::ById),
+            b'I' => Some(DeleteTarget::ByIdIncludingScrollback),
+            b'n' => Some(DeleteTarget::ByNumber),
+            b'N' => Some(DeleteTarget::ByNumberIncludingScrollback),
+            b'c' => Some(DeleteTarget::AtCursor),
+            b'C' => Some(DeleteTarget::AtCursorIncludingScrollback),
+            b'f' => Some(DeleteTarget::AnimationFrames),
+            b'F' => Some(DeleteTarget::AnimationFramesIncludingScrollback),
+            b'p' => Some(DeleteTarget::ByPlacementId),
+            b'P' => Some(DeleteTarget::ByPlacementIdIncludingScrollback),
+            b'q' => Some(DeleteTarget::ByColumn),
+            b'Q' => Some(DeleteTarget::ByColumnIncludingScrollback),
+            b'r' => Some(DeleteTarget::ByRow),
+            b'R' => Some(DeleteTarget::ByRowIncludingScrollback),
+            b'x' => Some(DeleteTarget::ByCell),
+            b'X' => Some(DeleteTarget::ByCellIncludingScrollback),
+            b'y' => Some(DeleteTarget::ByCellZ),
+            b'Y' => Some(DeleteTarget::ByCellZIncludingScrollback),
+            b'z' => Some(DeleteTarget::ByZIndex),
+            b'Z' => Some(DeleteTarget::ByZIndexIncludingScrollback),
+            _ => None,
+        }
+    }
+}
+
+/// Parsed kitty graphics command.
+///
+/// Contains all the fields from a kitty graphics APC sequence. Not all fields
+/// are meaningful for every action — they are overloaded based on context.
+#[derive(Debug, Clone)]
+pub struct KittyCommand {
+    /// Action type (`a=`). Default: Transmit.
+    pub action: Action,
+    /// Quiet mode (`q=`). Default: None.
+    pub quiet: Quiet,
+    /// Image ID (`i=`).
+    pub image_id: u32,
+    /// Image number (`I=`).
+    pub image_number: u32,
+    /// Placement ID (`p=`).
+    pub placement_id: u32,
+    /// Image data format (`f=`). Default: Rgba.
+    pub format: Format,
+    /// Transmission medium (`t=`). Default: Direct.
+    pub medium: Medium,
+    /// Compression (`o=`). Default: None.
+    pub compression: Compression,
+    /// More chunks follow (`m=`). Default: false.
+    pub more_chunks: bool,
+    /// Pixel width of source data (`s=`).
+    pub width: u32,
+    /// Pixel height of source data (`v=`).
+    pub height: u32,
+    /// Data size in bytes (`S=`).
+    pub data_size: u32,
+    /// Data offset (`O=`).
+    pub data_offset: u32,
+    // Display / placement keys:
+    /// Source rect x (`x=`).
+    pub src_x: u32,
+    /// Source rect y (`y=`).
+    pub src_y: u32,
+    /// Source rect width (`w=`).
+    pub src_w: u32,
+    /// Source rect height (`h=`).
+    pub src_h: u32,
+    /// Cell pixel X offset (`X=`).
+    pub offset_x: u32,
+    /// Cell pixel Y offset (`Y=`).
+    pub offset_y: u32,
+    /// Display columns (`c=`).
+    pub columns: u32,
+    /// Display rows (`r=`).
+    pub rows: u32,
+    /// Z-index (`z=`), signed.
+    pub z_index: i32,
+    /// Cursor movement control (`C=`). 0=move (default), 1=don't move.
+    pub cursor_movement: u32,
+    /// Virtual placement (`U=`). 0=false, 1=true.
+    pub virtual_placement: u32,
+    /// Parent image ID for relative placement (`P=`).
+    pub parent_id: u32,
+    /// Parent placement ID for relative placement (`Q=`).
+    pub parent_placement_id: u32,
+    /// Horizontal offset for relative placement (`H=`), signed.
+    pub horizontal_offset: i32,
+    /// Vertical offset for relative placement (`V=`), signed.
+    pub vertical_offset: i32,
+    /// Delete target (`d=`).
+    pub delete: Option<DeleteTarget>,
+    // Animation keys (overloaded):
+    /// Animation state for control (`s=` in animation context).
+    pub anim_state: u32,
+    /// Frame gap in ms (`z=` in animation frame context), signed.
+    pub gap_ms: i32,
+    /// Composition mode for animation frames (`X=` in frame context).
+    pub compose_mode: u32,
+    /// Background pixel color for animation (`Y=` in frame context).
+    pub background: u32,
+    /// Loop count for animation (`v=` in animation control context).
+    pub loops: u32,
+
+    /// The raw base64 payload bytes (after `;`).
+    pub payload: Vec<u8>,
+}
+
+impl Default for KittyCommand {
+    fn default() -> Self {
+        KittyCommand {
+            action: Action::Transmit,
+            quiet: Quiet::None,
+            image_id: 0,
+            image_number: 0,
+            placement_id: 0,
+            format: Format::Rgba,
+            medium: Medium::Direct,
+            compression: Compression::None,
+            more_chunks: false,
+            width: 0,
+            height: 0,
+            data_size: 0,
+            data_offset: 0,
+            src_x: 0,
+            src_y: 0,
+            src_w: 0,
+            src_h: 0,
+            offset_x: 0,
+            offset_y: 0,
+            columns: 0,
+            rows: 0,
+            z_index: 0,
+            cursor_movement: 0,
+            virtual_placement: 0,
+            parent_id: 0,
+            parent_placement_id: 0,
+            horizontal_offset: 0,
+            vertical_offset: 0,
+            delete: None,
+            anim_state: 0,
+            gap_ms: 0,
+            compose_mode: 0,
+            background: 0,
+            loops: 0,
+            payload: Vec::new(),
+        }
+    }
+}
+
+/// Accumulator for APC bytes. Collects bytes during apc_put and parses
+/// at apc_end.
+#[derive(Debug, Default)]
+pub struct KittyApcBuffer {
+    /// Raw bytes accumulated during APC sequence.
+    buf: Vec<u8>,
+    /// Whether the first byte was 'G' (valid kitty graphics sequence).
+    is_kitty: Option<bool>,
+}
+
+impl KittyApcBuffer {
+    /// Create a new empty APC buffer.
+    #[must_use]
+    pub fn new() -> Self {
+        KittyApcBuffer {
+            buf: Vec::with_capacity(8192),
+            is_kitty: None,
+        }
+    }
+
+    /// Reset the buffer for a new APC sequence.
+    pub fn start(&mut self) {
+        self.buf.clear();
+        self.is_kitty = None;
+    }
+
+    /// Add a byte to the buffer. Returns false if this is definitely
+    /// not a kitty graphics sequence.
+    pub fn put(&mut self, byte: u8) -> bool {
+        if self.is_kitty == Some(false) {
+            return false;
+        }
+        if self.is_kitty.is_none() {
+            // First byte determines if this is a kitty graphics sequence.
+            self.is_kitty = Some(byte == b'G');
+            if byte != b'G' {
+                return false;
+            }
+            // Don't store the 'G' prefix.
+            return true;
+        }
+        self.buf.push(byte);
+        true
+    }
+
+    /// Finalize the buffer and parse the command. Returns None if this
+    /// was not a kitty graphics sequence or if parsing failed.
+    pub fn finish(&mut self) -> Option<KittyCommand> {
+        if self.is_kitty != Some(true) {
+            return None;
+        }
+        let result = parse_command(&self.buf);
+        self.buf.clear();
+        self.is_kitty = None;
+        result
+    }
+}
+
+/// Parse a kitty graphics command from the APC payload (after 'G' prefix).
+///
+/// Format: `key=value[,key=value...][;base64_payload]`
+fn parse_command(data: &[u8]) -> Option<KittyCommand> {
+    let mut cmd = KittyCommand::default();
+
+    // Split at first ';' into key-value part and payload.
+    let (kv_part, payload) = match data.iter().position(|&b| b == b';') {
+        Some(pos) => (&data[..pos], &data[pos + 1..]),
+        None => (data, &[] as &[u8]),
+    };
+
+    cmd.payload = payload.to_vec();
+
+    // Parse key=value pairs separated by ','.
+    if !kv_part.is_empty() {
+        let kv_str = std::str::from_utf8(kv_part).ok()?;
+        for pair in kv_str.split(',') {
+            if pair.is_empty() {
+                continue;
+            }
+            let mut iter = pair.splitn(2, '=');
+            let key = iter.next()?;
+            let value = iter.next().unwrap_or("");
+
+            // Keys must be single characters.
+            if key.len() != 1 {
+                debug!("[kitty] ignoring multi-char key: {key}");
+                continue;
+            }
+
+            let key_byte = key.as_bytes()[0];
+            apply_key_value(&mut cmd, key_byte, value);
+        }
+    }
+
+    Some(cmd)
+}
+
+/// Apply a single key=value pair to the command.
+fn apply_key_value(cmd: &mut KittyCommand, key: u8, value: &str) {
+    match key {
+        b'a' => {
+            if let Some(b) = value.bytes().next() {
+                if let Some(action) = Action::from_byte(b) {
+                    cmd.action = action;
+                }
+            }
+        },
+        b'q' => {
+            if let Ok(v) = value.parse::<u32>() {
+                if let Some(quiet) = Quiet::from_u32(v) {
+                    cmd.quiet = quiet;
+                }
+            }
+        },
+        b'i' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.image_id = v;
+            }
+        },
+        b'I' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.image_number = v;
+            }
+        },
+        b'p' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.placement_id = v;
+            }
+        },
+        b'f' => {
+            if let Ok(v) = value.parse::<u32>() {
+                if let Some(fmt) = Format::from_u32(v) {
+                    cmd.format = fmt;
+                }
+            }
+        },
+        b't' => {
+            if let Some(b) = value.bytes().next() {
+                if let Some(medium) = Medium::from_byte(b) {
+                    cmd.medium = medium;
+                }
+            }
+        },
+        b'o' => {
+            if let Some(b) = value.bytes().next() {
+                if let Some(comp) = Compression::from_byte(b) {
+                    cmd.compression = comp;
+                }
+            }
+        },
+        b'm' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.more_chunks = v > 0;
+            }
+        },
+        b's' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.width = v;
+            }
+        },
+        b'v' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.height = v;
+            }
+        },
+        b'S' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.data_size = v;
+            }
+        },
+        b'O' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.data_offset = v;
+            }
+        },
+        b'x' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.src_x = v;
+            }
+        },
+        b'y' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.src_y = v;
+            }
+        },
+        b'w' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.src_w = v;
+            }
+        },
+        b'h' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.src_h = v;
+            }
+        },
+        b'X' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.offset_x = v;
+            }
+        },
+        b'Y' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.offset_y = v;
+            }
+        },
+        b'c' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.columns = v;
+            }
+        },
+        b'r' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.rows = v;
+            }
+        },
+        b'z' => {
+            if let Ok(v) = value.parse::<i32>() {
+                cmd.z_index = v;
+            }
+        },
+        b'C' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.cursor_movement = v;
+            }
+        },
+        b'U' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.virtual_placement = v;
+            }
+        },
+        b'P' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.parent_id = v;
+            }
+        },
+        b'Q' => {
+            if let Ok(v) = value.parse::<u32>() {
+                cmd.parent_placement_id = v;
+            }
+        },
+        b'H' => {
+            if let Ok(v) = value.parse::<i32>() {
+                cmd.horizontal_offset = v;
+            }
+        },
+        b'V' => {
+            if let Ok(v) = value.parse::<i32>() {
+                cmd.vertical_offset = v;
+            }
+        },
+        b'd' => {
+            if let Some(b) = value.bytes().next() {
+                cmd.delete = DeleteTarget::from_byte(b);
+            }
+        },
+        _ => {
+            debug!("[kitty] unknown key: {} = {}", key as char, value);
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_transmit_and_display_png() {
+        // a=T,f=100,i=1;base64data
+        let data = b"a=T,f=100,i=1;AAAA";
+        let cmd = parse_command(data).unwrap();
+        assert_eq!(cmd.action, Action::TransmitAndDisplay);
+        assert_eq!(cmd.format, Format::Png);
+        assert_eq!(cmd.image_id, 1);
+        assert_eq!(cmd.payload, b"AAAA");
+    }
+
+    #[test]
+    fn parse_transmit_default_action() {
+        // No a= means default Transmit.
+        let data = b"f=32,s=100,v=100;payload";
+        let cmd = parse_command(data).unwrap();
+        assert_eq!(cmd.action, Action::Transmit);
+        assert_eq!(cmd.format, Format::Rgba);
+        assert_eq!(cmd.width, 100);
+        assert_eq!(cmd.height, 100);
+        assert_eq!(cmd.payload, b"payload");
+    }
+
+    #[test]
+    fn parse_query() {
+        let data = b"a=q,i=42,f=100;";
+        let cmd = parse_command(data).unwrap();
+        assert_eq!(cmd.action, Action::Query);
+        assert_eq!(cmd.image_id, 42);
+        assert_eq!(cmd.format, Format::Png);
+    }
+
+    #[test]
+    fn parse_display() {
+        let data = b"a=p,i=5,p=1,c=10,r=5,z=-1";
+        let cmd = parse_command(data).unwrap();
+        assert_eq!(cmd.action, Action::Display);
+        assert_eq!(cmd.image_id, 5);
+        assert_eq!(cmd.placement_id, 1);
+        assert_eq!(cmd.columns, 10);
+        assert_eq!(cmd.rows, 5);
+        assert_eq!(cmd.z_index, -1);
+        assert!(cmd.payload.is_empty());
+    }
+
+    #[test]
+    fn parse_delete_all() {
+        let data = b"a=d,d=a";
+        let cmd = parse_command(data).unwrap();
+        assert_eq!(cmd.action, Action::Delete);
+        assert_eq!(cmd.delete, Some(DeleteTarget::All));
+    }
+
+    #[test]
+    fn parse_delete_by_id() {
+        let data = b"a=d,d=i,i=42";
+        let cmd = parse_command(data).unwrap();
+        assert_eq!(cmd.action, Action::Delete);
+        assert_eq!(cmd.delete, Some(DeleteTarget::ById));
+        assert_eq!(cmd.image_id, 42);
+    }
+
+    #[test]
+    fn parse_chunked_more() {
+        let data = b"a=T,f=100,m=1;chunk1data";
+        let cmd = parse_command(data).unwrap();
+        assert_eq!(cmd.action, Action::TransmitAndDisplay);
+        assert!(cmd.more_chunks);
+        assert_eq!(cmd.payload, b"chunk1data");
+    }
+
+    #[test]
+    fn parse_chunked_last() {
+        let data = b"m=0;lastchunk";
+        let cmd = parse_command(data).unwrap();
+        assert!(!cmd.more_chunks);
+        assert_eq!(cmd.payload, b"lastchunk");
+    }
+
+    #[test]
+    fn parse_compression_zlib() {
+        let data = b"f=32,o=z,s=10,v=10;compresseddata";
+        let cmd = parse_command(data).unwrap();
+        assert_eq!(cmd.compression, Compression::Zlib);
+    }
+
+    #[test]
+    fn parse_quiet_modes() {
+        let data = b"a=T,q=1,f=100;data";
+        let cmd = parse_command(data).unwrap();
+        assert_eq!(cmd.quiet, Quiet::SuppressOk);
+
+        let data = b"a=T,q=2,f=100;data";
+        let cmd = parse_command(data).unwrap();
+        assert_eq!(cmd.quiet, Quiet::SuppressAll);
+    }
+
+    #[test]
+    fn parse_placement_keys() {
+        let data = b"a=p,i=1,x=10,y=20,w=100,h=50,X=5,Y=3,C=1";
+        let cmd = parse_command(data).unwrap();
+        assert_eq!(cmd.src_x, 10);
+        assert_eq!(cmd.src_y, 20);
+        assert_eq!(cmd.src_w, 100);
+        assert_eq!(cmd.src_h, 50);
+        assert_eq!(cmd.offset_x, 5);
+        assert_eq!(cmd.offset_y, 3);
+        assert_eq!(cmd.cursor_movement, 1);
+    }
+
+    #[test]
+    fn parse_empty_payload() {
+        let data = b"a=q,i=1";
+        let cmd = parse_command(data).unwrap();
+        assert!(cmd.payload.is_empty());
+    }
+
+    #[test]
+    fn parse_with_semicolon_no_payload() {
+        let data = b"a=q,i=1;";
+        let cmd = parse_command(data).unwrap();
+        assert!(cmd.payload.is_empty());
+    }
+
+    #[test]
+    fn parse_unknown_keys_ignored() {
+        // Unknown keys are silently ignored.
+        let data = b"a=T,Z=999,f=100;data";
+        let cmd = parse_command(data).unwrap();
+        assert_eq!(cmd.action, Action::TransmitAndDisplay);
+        assert_eq!(cmd.format, Format::Png);
+    }
+
+    #[test]
+    fn parse_animation_frame() {
+        let data = b"a=f,i=1,r=2,z=40;framedata";
+        let cmd = parse_command(data).unwrap();
+        assert_eq!(cmd.action, Action::TransmitFrame);
+        assert_eq!(cmd.image_id, 1);
+        assert_eq!(cmd.rows, 2); // overloaded as edit_frame
+        assert_eq!(cmd.z_index, 40); // overloaded as gap_ms
+    }
+
+    #[test]
+    fn apc_buffer_kitty_sequence() {
+        let mut buf = KittyApcBuffer::new();
+        buf.start();
+        
+        // Simulate bytes: G a = T , f = 1 0 0 ; d a t a
+        for &b in b"Ga=T,f=100;data" {
+            buf.put(b);
+        }
+        
+        let cmd = buf.finish().unwrap();
+        assert_eq!(cmd.action, Action::TransmitAndDisplay);
+        assert_eq!(cmd.format, Format::Png);
+        assert_eq!(cmd.payload, b"data");
+    }
+
+    #[test]
+    fn apc_buffer_non_kitty_sequence() {
+        let mut buf = KittyApcBuffer::new();
+        buf.start();
+        
+        // Not starting with 'G'.
+        assert!(!buf.put(b'X'));
+        assert!(buf.finish().is_none());
+    }
+
+    #[test]
+    fn apc_buffer_reuse() {
+        let mut buf = KittyApcBuffer::new();
+        
+        // First sequence.
+        buf.start();
+        for &b in b"Ga=q,i=1" {
+            buf.put(b);
+        }
+        let cmd = buf.finish().unwrap();
+        assert_eq!(cmd.action, Action::Query);
+        
+        // Second sequence (reuse buffer).
+        buf.start();
+        for &b in b"Ga=d,d=a" {
+            buf.put(b);
+        }
+        let cmd = buf.finish().unwrap();
+        assert_eq!(cmd.action, Action::Delete);
+    }
+
+    #[test]
+    fn parse_relative_placement() {
+        let data = b"a=p,i=1,P=10,Q=2,H=-5,V=3";
+        let cmd = parse_command(data).unwrap();
+        assert_eq!(cmd.parent_id, 10);
+        assert_eq!(cmd.parent_placement_id, 2);
+        assert_eq!(cmd.horizontal_offset, -5);
+        assert_eq!(cmd.vertical_offset, 3);
+    }
+}

--- a/alacritty_terminal/src/graphics/kitty_parser.rs
+++ b/alacritty_terminal/src/graphics/kitty_parser.rs
@@ -285,8 +285,13 @@ pub struct KittyCommand {
     /// Loop count for animation (`v=` in animation control context).
     pub loops: u32,
 
-    /// The raw base64 payload bytes (after `;`).
+    /// The raw base64 payload bytes (after `;`), or pre-decoded raw bytes
+    /// if `pre_decoded` is true (set by chunked transfer finalization).
     pub payload: Vec<u8>,
+
+    /// When true, `payload` contains already-decoded raw bytes (not base64).
+    /// Set by `finalize_chunked` after per-chunk base64 decoding.
+    pub pre_decoded: bool,
 }
 
 impl Default for KittyCommand {
@@ -327,6 +332,7 @@ impl Default for KittyCommand {
             background: 0,
             loops: 0,
             payload: Vec::new(),
+            pre_decoded: false,
         }
     }
 }

--- a/alacritty_terminal/src/graphics/mod.rs
+++ b/alacritty_terminal/src/graphics/mod.rs
@@ -1,6 +1,8 @@
 //! This module implements the logic to manage graphic items included in a
 //! `Grid` instance.
 
+pub mod kitty;
+pub mod kitty_parser;
 pub mod sixel;
 
 use std::collections::HashSet;
@@ -314,6 +316,15 @@ pub struct Graphics {
 
     /// Current Sixel parser.
     pub sixel_parser: Option<Box<sixel::Parser>>,
+
+    /// Buffer for accumulating kitty graphics APC sequences.
+    pub kitty_apc_buffer: Option<kitty_parser::KittyApcBuffer>,
+
+    /// Last parsed kitty graphics command (for dispatch and testing).
+    pub last_kitty_command: Option<kitty_parser::KittyCommand>,
+
+    /// Kitty graphics protocol state (image storage, chunked transfers, etc.).
+    pub kitty_state: kitty::KittyState,
 }
 
 impl Graphics {

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -3599,4 +3599,294 @@ mod tests {
         assert_eq!(cmd.action, Action::Query);
         assert_eq!(cmd.image_id, 1);
     }
+
+    // ── Phase 2: End-to-end integration tests ─────────────────────────
+    //
+    // These feed raw APC bytes through the full VTE → Parser → Term →
+    // dispatch_command pipeline and verify the resulting state (images
+    // stored, deletions applied, animation states created, etc.).
+
+    /// Helper: base64-encode a WxH solid-color RGBA image.
+    fn make_rgba_b64(width: usize, height: usize, r: u8, g: u8, b: u8, a: u8) -> String {
+        use base64::Engine;
+        let pixels: Vec<u8> = [r, g, b, a].repeat(width * height);
+        base64::engine::general_purpose::STANDARD.encode(&pixels)
+    }
+
+    #[test]
+    fn kitty_e2e_transmit_stores_image() {
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        let b64 = make_rgba_b64(2, 2, 255, 0, 0, 255);
+        let apc = format!("\x1b_Ga=t,f=32,s=2,v=2,i=1;{b64}\x1b\\");
+        feed_bytes(&mut term, apc.as_bytes());
+
+        let img = term.graphics.kitty_state.get_image(1)
+            .expect("image 1 should be stored after transmit");
+        assert_eq!(img.data.width, 2);
+        assert_eq!(img.data.height, 2);
+        assert_eq!(img.data.pixels.len(), 16);
+        assert_eq!(img.total_bytes, 16);
+    }
+
+    #[test]
+    fn kitty_e2e_transmit_and_display_stores_image() {
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        let b64 = make_rgba_b64(2, 2, 0, 255, 0, 255);
+        let apc = format!("\x1b_Ga=T,f=32,s=2,v=2,i=5;{b64}\x1b\\");
+        feed_bytes(&mut term, apc.as_bytes());
+
+        let img = term.graphics.kitty_state.get_image(5)
+            .expect("image 5 should be stored after transmit+display");
+        assert_eq!(img.data.width, 2);
+        assert_eq!(img.data.height, 2);
+    }
+
+    #[test]
+    fn kitty_e2e_delete_by_id_removes_image() {
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        // Transmit two images.
+        let b64 = make_rgba_b64(1, 1, 255, 0, 0, 255);
+        feed_bytes(&mut term, format!("\x1b_Ga=t,f=32,s=1,v=1,i=10;{b64}\x1b\\").as_bytes());
+        feed_bytes(&mut term, format!("\x1b_Ga=t,f=32,s=1,v=1,i=20;{b64}\x1b\\").as_bytes());
+        assert!(term.graphics.kitty_state.get_image(10).is_some());
+        assert!(term.graphics.kitty_state.get_image(20).is_some());
+
+        // Delete image 10 by ID.
+        feed_bytes(&mut term, b"\x1b_Ga=d,d=i,i=10\x1b\\");
+
+        assert!(term.graphics.kitty_state.get_image(10).is_none(), "image 10 should be deleted");
+        assert!(term.graphics.kitty_state.get_image(20).is_some(), "image 20 should survive");
+    }
+
+    #[test]
+    fn kitty_e2e_delete_all_clears_storage() {
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        let b64 = make_rgba_b64(1, 1, 0, 0, 255, 255);
+        for id in 1..=5u32 {
+            let apc = format!("\x1b_Ga=t,f=32,s=1,v=1,i={id};{b64}\x1b\\");
+            feed_bytes(&mut term, apc.as_bytes());
+        }
+        assert_eq!(term.graphics.kitty_state.images.len(), 5);
+
+        feed_bytes(&mut term, b"\x1b_Ga=d,d=a\x1b\\");
+
+        assert!(term.graphics.kitty_state.images.is_empty(), "all images should be deleted");
+        assert_eq!(term.graphics.kitty_state.used_memory, 0);
+    }
+
+    #[test]
+    fn kitty_e2e_chunked_transfer_merges_and_stores() {
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        // 2x2 RGBA = 16 bytes. Split the base64 into two chunks.
+        let b64 = make_rgba_b64(2, 2, 128, 64, 32, 255);
+        let mid = b64.len() / 2;
+        let chunk1 = &b64[..mid];
+        let chunk2 = &b64[mid..];
+
+        // First chunk (m=1 = more coming).
+        let apc1 = format!("\x1b_Ga=T,f=32,s=2,v=2,i=99,m=1;{chunk1}\x1b\\");
+        feed_bytes(&mut term, apc1.as_bytes());
+        assert!(term.graphics.kitty_state.get_image(99).is_none(),
+            "image should NOT be stored mid-transfer");
+        assert!(term.graphics.kitty_state.loading.is_some());
+
+        // Final chunk (m=0).
+        let apc2 = format!("\x1b_Gm=0;{chunk2}\x1b\\");
+        feed_bytes(&mut term, apc2.as_bytes());
+
+        let img = term.graphics.kitty_state.get_image(99)
+            .expect("image should be stored after final chunk");
+        assert_eq!(img.data.width, 2);
+        assert_eq!(img.data.height, 2);
+        assert_eq!(img.data.pixels.len(), 16);
+        assert!(term.graphics.kitty_state.loading.is_none());
+    }
+
+    #[test]
+    fn kitty_e2e_file_medium_reads_and_stores() {
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        // Write raw RGBA pixel data to a temp file.
+        let pixels: Vec<u8> = vec![
+            255, 128, 64, 255, 0, 0, 0, 255,
+            64, 128, 255, 255, 255, 255, 255, 255,
+        ];
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("kitty_e2e_file_{}.rgba", std::process::id()));
+        std::fs::write(&path, &pixels).expect("write temp file");
+
+        // Base64-encode the file path for the payload.
+        use base64::Engine;
+        let path_b64 = base64::engine::general_purpose::STANDARD
+            .encode(path.to_str().unwrap().as_bytes());
+
+        let apc = format!("\x1b_Ga=t,t=f,f=32,s=2,v=2,i=50;{path_b64}\x1b\\");
+        feed_bytes(&mut term, apc.as_bytes());
+
+        let img = term.graphics.kitty_state.get_image(50)
+            .expect("image should be stored from file medium");
+        assert_eq!(img.data.width, 2);
+        assert_eq!(img.data.height, 2);
+        assert_eq!(img.data.pixels, pixels);
+
+        // Clean up.
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn kitty_e2e_image_number_mapping() {
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        // Transmit with both image_id (i=) and image_number (I=).
+        let b64 = make_rgba_b64(1, 1, 255, 255, 0, 255);
+        let apc = format!("\x1b_Ga=t,f=32,s=1,v=1,i=7,I=100;{b64}\x1b\\");
+        feed_bytes(&mut term, apc.as_bytes());
+
+        assert!(term.graphics.kitty_state.get_image(7).is_some());
+        assert_eq!(term.graphics.kitty_state.resolve_number(100), Some(7));
+
+        // Display by number (a=p with I=100).
+        feed_bytes(&mut term, b"\x1b_Ga=p,I=100\x1b\\");
+        assert!(term.graphics.kitty_state.get_image(7).is_some());
+    }
+
+    #[test]
+    fn kitty_e2e_delete_by_number() {
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        let b64 = make_rgba_b64(1, 1, 0, 0, 0, 255);
+        feed_bytes(&mut term,
+            format!("\x1b_Ga=t,f=32,s=1,v=1,i=3,I=200;{b64}\x1b\\").as_bytes());
+        assert!(term.graphics.kitty_state.get_image(3).is_some());
+
+        // Delete by image number.
+        feed_bytes(&mut term, b"\x1b_Ga=d,d=n,I=200\x1b\\");
+        assert!(term.graphics.kitty_state.get_image(3).is_none(),
+            "image should be deleted via number mapping");
+        assert_eq!(term.graphics.kitty_state.resolve_number(200), None);
+    }
+
+    #[test]
+    fn kitty_e2e_replace_image_updates_storage() {
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        // Store a 1x1 image.
+        let b64_small = make_rgba_b64(1, 1, 255, 0, 0, 255);
+        feed_bytes(&mut term,
+            format!("\x1b_Ga=t,f=32,s=1,v=1,i=8;{b64_small}\x1b\\").as_bytes());
+        assert_eq!(term.graphics.kitty_state.get_image(8).unwrap().data.pixels.len(), 4);
+
+        // Replace with a 2x2 image using the same ID.
+        let b64_big = make_rgba_b64(2, 2, 0, 255, 0, 255);
+        feed_bytes(&mut term,
+            format!("\x1b_Ga=t,f=32,s=2,v=2,i=8;{b64_big}\x1b\\").as_bytes());
+        let img = term.graphics.kitty_state.get_image(8).unwrap();
+        assert_eq!(img.data.width, 2);
+        assert_eq!(img.data.height, 2);
+        assert_eq!(img.data.pixels.len(), 16);
+    }
+
+    #[test]
+    fn kitty_e2e_query_does_not_store() {
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        let b64 = make_rgba_b64(1, 1, 255, 0, 0, 255);
+        feed_bytes(&mut term,
+            format!("\x1b_Ga=q,f=32,i=42;{b64}\x1b\\").as_bytes());
+
+        // Query should validate but NOT store the image.
+        assert!(term.graphics.kitty_state.get_image(42).is_none(),
+            "query should not store images");
+        assert!(term.graphics.kitty_state.images.is_empty());
+    }
+
+    #[test]
+    fn kitty_e2e_animation_frame_creates_state() {
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        // Transmit a base image.
+        let b64 = make_rgba_b64(2, 2, 255, 0, 0, 255);
+        feed_bytes(&mut term,
+            format!("\x1b_Ga=T,f=32,s=2,v=2,i=30;{b64}\x1b\\").as_bytes());
+        assert!(term.graphics.kitty_state.get_image(30).is_some());
+        assert!(term.graphics.kitty_state.get_animation(30).is_none(),
+            "no animation state before first frame");
+
+        // Send an animation frame (a=f) with 100ms gap.
+        let frame_b64 = make_rgba_b64(2, 2, 0, 255, 0, 255);
+        feed_bytes(&mut term,
+            format!("\x1b_Ga=f,i=30,f=32,s=2,v=2,z=100;{frame_b64}\x1b\\").as_bytes());
+
+        assert!(term.graphics.kitty_state.get_animation(30).is_some(),
+            "animation state should exist after frame transmit");
+        let anim = term.graphics.kitty_state.get_animation(30).unwrap();
+        assert!(anim.frames.len() >= 2,
+            "should have at least 2 frames (original + new)");
+    }
+
+    #[test]
+    fn kitty_e2e_delete_clears_animation_state() {
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        // Transmit image + animation frame.
+        let b64 = make_rgba_b64(1, 1, 255, 0, 0, 255);
+        feed_bytes(&mut term,
+            format!("\x1b_Ga=T,f=32,s=1,v=1,i=40;{b64}\x1b\\").as_bytes());
+        let frame_b64 = make_rgba_b64(1, 1, 0, 0, 255, 255);
+        feed_bytes(&mut term,
+            format!("\x1b_Ga=f,i=40,f=32,s=1,v=1;{frame_b64}\x1b\\").as_bytes());
+        assert!(term.graphics.kitty_state.get_animation(40).is_some());
+
+        // Delete by ID should also clear animation.
+        feed_bytes(&mut term, b"\x1b_Ga=d,d=i,i=40\x1b\\");
+        assert!(term.graphics.kitty_state.get_image(40).is_none());
+        assert!(term.graphics.kitty_state.get_animation(40).is_none(),
+            "animation state should be cleared on delete");
+    }
+
+    #[test]
+    fn kitty_e2e_multiple_images_memory_tracking() {
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        // Store three images of different sizes.
+        let b64_1x1 = make_rgba_b64(1, 1, 255, 0, 0, 255); // 4 bytes
+        let b64_2x2 = make_rgba_b64(2, 2, 0, 255, 0, 255); // 16 bytes
+        let b64_3x3 = make_rgba_b64(3, 3, 0, 0, 255, 255); // 36 bytes
+        feed_bytes(&mut term,
+            format!("\x1b_Ga=t,f=32,s=1,v=1,i=1;{b64_1x1}\x1b\\").as_bytes());
+        feed_bytes(&mut term,
+            format!("\x1b_Ga=t,f=32,s=2,v=2,i=2;{b64_2x2}\x1b\\").as_bytes());
+        feed_bytes(&mut term,
+            format!("\x1b_Ga=t,f=32,s=3,v=3,i=3;{b64_3x3}\x1b\\").as_bytes());
+
+        assert_eq!(term.graphics.kitty_state.images.len(), 3);
+        assert_eq!(term.graphics.kitty_state.used_memory, 4 + 16 + 36);
+
+        // Delete one, verify memory adjusts.
+        feed_bytes(&mut term, b"\x1b_Ga=d,d=i,i=2\x1b\\");
+        assert_eq!(term.graphics.kitty_state.images.len(), 2);
+        assert_eq!(term.graphics.kitty_state.used_memory, 4 + 36);
+
+        // Delete all, verify zero.
+        feed_bytes(&mut term, b"\x1b_Ga=d,d=a\x1b\\");
+        assert_eq!(term.graphics.kitty_state.used_memory, 0);
+    }
 }

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -736,6 +736,11 @@ impl<T> Term<T> {
         &self.mode
     }
 
+    /// Get a reference to the event proxy for sending events.
+    pub fn event_proxy(&self) -> &T {
+        &self.event_proxy
+    }
+
     /// Swap primary and alternate screen buffer.
     pub fn swap_alt(&mut self) {
         if !self.mode.contains(TermMode::ALT_SCREEN) {
@@ -2373,6 +2378,42 @@ impl<T: EventListener> Handler for Term<T> {
             debug!("[unhandled dcs_unhook]");
         }
     }
+
+    /// Start of an APC (Application Program Command) sequence.
+    fn apc_start(&mut self) {
+        let buf = self
+            .graphics
+            .kitty_apc_buffer
+            .get_or_insert_with(crate::graphics::kitty_parser::KittyApcBuffer::new);
+        buf.start();
+    }
+
+    /// Byte of an APC string.
+    fn apc_put(&mut self, byte: u8) {
+        if let Some(buf) = &mut self.graphics.kitty_apc_buffer {
+            buf.put(byte);
+        }
+    }
+
+    /// End of an APC string.
+    fn apc_end(&mut self) {
+        if let Some(buf) = &mut self.graphics.kitty_apc_buffer {
+            if let Some(cmd) = buf.finish() {
+                debug!(
+                    "[kitty] command: action={:?}, id={}, fmt={:?}, medium={:?}, \
+                     more={}, payload_len={}",
+                    cmd.action,
+                    cmd.image_id,
+                    cmd.format,
+                    cmd.medium,
+                    cmd.more_chunks,
+                    cmd.payload.len(),
+                );
+                self.graphics.last_kitty_command = Some(cmd.clone());
+                crate::graphics::kitty::dispatch_command(self, cmd);
+            }
+        }
+    }
 }
 
 /// The state of the [`Mode`] and [`PrivateMode`].
@@ -2529,11 +2570,30 @@ pub mod test {
     pub struct TermSize {
         pub columns: usize,
         pub screen_lines: usize,
+        /// Cell width in pixels (used by sixel/graphics). Defaults to 8.
+        #[cfg_attr(feature = "serde", serde(default = "TermSize::default_cell_width"))]
+        pub cell_width: f32,
+        /// Cell height in pixels (used by sixel/graphics). Defaults to 16.
+        #[cfg_attr(feature = "serde", serde(default = "TermSize::default_cell_height"))]
+        pub cell_height: f32,
     }
 
     impl TermSize {
         pub fn new(columns: usize, screen_lines: usize) -> Self {
-            Self { columns, screen_lines }
+            Self {
+                columns,
+                screen_lines,
+                cell_width: Self::default_cell_width(),
+                cell_height: Self::default_cell_height(),
+            }
+        }
+
+        fn default_cell_width() -> f32 {
+            8.0
+        }
+
+        fn default_cell_height() -> f32 {
+            16.0
         }
     }
 
@@ -2548,6 +2608,14 @@ pub mod test {
 
         fn columns(&self) -> usize {
             self.columns
+        }
+
+        fn cell_width(&self) -> f32 {
+            self.cell_width
+        }
+
+        fn cell_height(&self) -> f32 {
+            self.cell_height
         }
     }
 
@@ -3402,5 +3470,133 @@ mod tests {
         assert_eq!(version_number("0.1.2-dev"), 1_02);
         assert_eq!(version_number("1.2.3-dev"), 1_02_03);
         assert_eq!(version_number("999.99.99"), 9_99_99_99);
+    }
+
+    // ── Kitty graphics APC integration tests ──────────────────────────
+
+    /// Feed raw bytes through the full VTE pipeline (Processor → Parser → Term).
+    fn feed_bytes(term: &mut Term<VoidListener>, bytes: &[u8]) {
+        let mut processor: crate::vte::ansi::Processor = crate::vte::ansi::Processor::new();
+        processor.advance(term, bytes);
+    }
+
+    /// Helper to get the last parsed kitty command from a term.
+    fn take_kitty_cmd(
+        term: &mut Term<VoidListener>,
+    ) -> Option<crate::graphics::kitty_parser::KittyCommand> {
+        term.graphics.last_kitty_command.take()
+    }
+
+    #[test]
+    fn kitty_apc_transmit_and_display_png() {
+        use crate::graphics::kitty_parser::{Action, Format, Medium};
+
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        // ESC _ G a=T,f=100,i=1;AAAA ESC \
+        feed_bytes(&mut term, b"\x1b_Ga=T,f=100,i=1;AAAA\x1b\\");
+
+        let cmd = take_kitty_cmd(&mut term).expect("should have parsed a kitty command");
+        assert_eq!(cmd.action, Action::TransmitAndDisplay);
+        assert_eq!(cmd.format, Format::Png);
+        assert_eq!(cmd.medium, Medium::Direct);
+        assert_eq!(cmd.image_id, 1);
+        assert_eq!(cmd.payload, b"AAAA");
+        assert!(!cmd.more_chunks);
+    }
+
+    #[test]
+    fn kitty_apc_query() {
+        use crate::graphics::kitty_parser::Action;
+
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        feed_bytes(&mut term, b"\x1b_Ga=q,i=42,f=100;\x1b\\");
+
+        let cmd = take_kitty_cmd(&mut term).expect("should have parsed a query");
+        assert_eq!(cmd.action, Action::Query);
+        assert_eq!(cmd.image_id, 42);
+    }
+
+    #[test]
+    fn kitty_apc_delete_all() {
+        use crate::graphics::kitty_parser::{Action, DeleteTarget};
+
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        feed_bytes(&mut term, b"\x1b_Ga=d,d=a\x1b\\");
+
+        let cmd = take_kitty_cmd(&mut term).expect("should have parsed a delete");
+        assert_eq!(cmd.action, Action::Delete);
+        assert_eq!(cmd.delete, Some(DeleteTarget::All));
+    }
+
+    #[test]
+    fn kitty_apc_chunked_sequence() {
+        use crate::graphics::kitty_parser::Action;
+
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        // First chunk: m=1 (more coming).
+        feed_bytes(&mut term, b"\x1b_Ga=T,f=100,m=1;chunk1\x1b\\");
+        let cmd1 = take_kitty_cmd(&mut term).expect("should parse first chunk");
+        assert_eq!(cmd1.action, Action::TransmitAndDisplay);
+        assert!(cmd1.more_chunks);
+        assert_eq!(cmd1.payload, b"chunk1");
+
+        // Last chunk: m=0.
+        feed_bytes(&mut term, b"\x1b_Gm=0;chunk2\x1b\\");
+        let cmd2 = take_kitty_cmd(&mut term).expect("should parse last chunk");
+        assert!(!cmd2.more_chunks);
+        assert_eq!(cmd2.payload, b"chunk2");
+    }
+
+    #[test]
+    fn kitty_apc_display_with_placement() {
+        use crate::graphics::kitty_parser::Action;
+
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        feed_bytes(&mut term, b"\x1b_Ga=p,i=5,p=1,c=10,r=5,z=-1,C=1\x1b\\");
+
+        let cmd = take_kitty_cmd(&mut term).expect("should parse display command");
+        assert_eq!(cmd.action, Action::Display);
+        assert_eq!(cmd.image_id, 5);
+        assert_eq!(cmd.placement_id, 1);
+        assert_eq!(cmd.columns, 10);
+        assert_eq!(cmd.rows, 5);
+        assert_eq!(cmd.z_index, -1);
+        assert_eq!(cmd.cursor_movement, 1);
+    }
+
+    #[test]
+    fn kitty_apc_non_kitty_ignored() {
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        // APC that doesn't start with 'G' — not kitty graphics.
+        feed_bytes(&mut term, b"\x1b_Xsomething\x1b\\");
+
+        assert!(take_kitty_cmd(&mut term).is_none());
+    }
+
+    #[test]
+    fn kitty_apc_interleaved_with_text() {
+        use crate::graphics::kitty_parser::Action;
+
+        let size = TermSize::new(80, 24);
+        let mut term = Term::new(Config::default(), &size, VoidListener);
+
+        // Text, then kitty command, then more text.
+        feed_bytes(&mut term, b"Hello\x1b_Ga=q,i=1\x1b\\World");
+
+        let cmd = take_kitty_cmd(&mut term).expect("should parse command amid text");
+        assert_eq!(cmd.action, Action::Query);
+        assert_eq!(cmd.image_id, 1);
     }
 }

--- a/docs/kitty_graphics_plan.md
+++ b/docs/kitty_graphics_plan.md
@@ -1,0 +1,708 @@
+# Kitty Graphics Protocol — Alacritty Implementation Plan
+
+## Reference Material
+
+| Source | Location | Notes |
+|--------|----------|-------|
+| Protocol spec | https://sw.kovidgoyal.net/kitty/graphics-protocol/ | Canonical reference |
+| Ghostty impl | `../ghostty/src/terminal/kitty/` | Zig, ~6500 LOC, animation parsed but **unimplemented** |
+| WezTerm impl | `../wezterm/term/src/terminalstate/kitty.rs` | Rust, ~4200 LOC, animation **working** |
+| Alacritty graphics | `alacritty_terminal/src/graphics/` | Sixel works, rendering pipeline reusable |
+
+---
+
+## Architecture Overview
+
+```text
+ ┌────────────────────────────────────────────────────────────────────────┐
+ │                        CURRENT (Sixel only)                            │
+ │                                                                        │
+ │  PTY ──► vte-graphics ──► DCS 'q' ──► sixel::Parser ──► GraphicData    │
+ │                                                              │         │
+ │                                                              ▼         │
+ │                                                      insert_graphic()  │
+ │                                                              │         │
+ │                                                              ▼         │
+ │                                                     Grid cells get     │
+ │                                                     GraphicCell refs   │
+ │                                                              │         │
+ │                                    ┌─────────────────────────┘         │
+ │                                    ▼                                   │
+ │  display::draw() ──► take_queues() ──► GPU upload ──► shader draw      │
+ └────────────────────────────────────────────────────────────────────────┘
+
+ ┌──────────────────────────────────────────────────────────────────────────┐
+ │                       TARGET (Sixel + Kitty)                             │
+ │                                                                          │
+ │                        ┌──── DCS 'q' ──► sixel::Parser ──┐               │
+ │  PTY ──► vte-graphics ─┤                                  ├► GraphicData │
+ │                        └──── APC 'G' ──► kitty::Parser ──┘     │         │
+ │                                  │                              │        │
+ │                                  │ (responses)                  ▼        │
+ │                                  ▼                       insert_graphic()│
+ │                            PTY write-back                       │        │
+ │                            ESC _Gi=N;OK                         ▼        │
+ │                                                          Grid cells      │
+ │                                                                │         │
+ │                                    ┌───────────────────────────┘         │
+ │                                    ▼                                     │
+ │  display::draw() ──► take_queues() ──► GPU upload ──► shader draw        │
+ │                          │                                               │
+ │                          ├► animation tick ──► re-upload changed frames  │
+ │                          └► placement management (z-order, delete)       │
+ └──────────────────────────────────────────────────────────────────────────┘
+```
+
+The key insight: `GraphicData` is **protocol-agnostic**. Once kitty bytes become
+a decoded pixel buffer, the entire GPU pipeline (texture upload, cell attachment,
+shader rendering) works identically to sixel. The new work is:
+
+1. Getting APC bytes routed to our parser
+2. Parsing the kitty key=value protocol
+3. Managing kitty-specific state (image IDs, placements, chunked transfer)
+4. Animation (multi-frame images, timed playback, frame composition)
+
+---
+
+## Phase 0 — APC Routing in the VTE Layer
+
+**Problem:** `vte-graphics` 0.15 (the VT parser crate) dispatches DCS sequences
+but does **not** dispatch APC sequences. The kitty graphics protocol uses APC
+(`ESC _G...ST`). This is the first blocker.
+
+**Approach — patch `vte-graphics`:**
+
+The crate is already a fork of `vte` with graphics extensions. Add APC callbacks
+following the same pattern as the existing DCS hooks:
+
+```text
+File: vte-graphics (vendored or patched dependency)
+
+  trait Perform {
+      // Existing:
+      fn dcs_hook(&mut self, params: &Params, intermediates: &[u8], ignore: bool, action: char);
+      fn dcs_put(&mut self, byte: u8);
+      fn dcs_unhook(&mut self);
+
+      // NEW:
++     fn apc_start(&mut self);        // ESC _ received
++     fn apc_put(&mut self, byte: u8); // payload bytes
++     fn apc_end(&mut self);           // ST received (ESC \ or BEL)
+  }
+```
+
+The VTE state machine already recognizes the `APC_STRING` state; it just doesn't
+call anything. Wire it up.
+
+**Files touched:**
+- `Cargo.toml` — point `vte` dependency to patched version (git or path)
+- `alacritty_terminal/src/term/mod.rs` — implement `apc_start/put/end` in `Handler`
+
+**Validation:**
+- `printf '\e_Gtest\e\\'` should hit the new handlers
+- No regressions in sixel, keyboard, or existing VT behavior
+
+**Estimated effort:** Small. The VTE state machine already parses APC; we just
+need to connect the dispatch.
+
+---
+
+## Phase 1 — Static Image Display (MVP)
+
+Goal: `kitty +kitten icat image.png` works.
+
+### 1a. Kitty Key-Value Parser
+
+**New file:** `alacritty_terminal/src/graphics/kitty.rs`
+
+Parse `ESC _G<key>=<value>[,<key>=<value>...];<base64 payload>ESC \`
+
+```text
+struct KittyCommand {
+    action: Action,           // a= : t, T, q, p, d, f, a, c
+    quiet: u8,                // q= : 0, 1, 2
+    image_id: u32,            // i=
+    image_number: u32,        // I=
+    placement_id: u32,        // p=
+    format: Format,           // f= : 24, 32, 100 (PNG)
+    transmission: Medium,     // t= : d, f, t, s
+    compression: Compression, // o= : z (zlib)
+    more_chunks: bool,        // m= : 0 or 1
+    width: u32,               // s= (pixel width of transmitted data)
+    height: u32,              // v= (pixel height of transmitted data)
+    // Display/placement keys:
+    src_x: u32,               // x= (source rect)
+    src_y: u32,               // y=
+    src_w: u32,               // w=
+    src_h: u32,               // h=
+    offset_x: u32,            // X= (cell pixel offset)
+    offset_y: u32,            // Y=
+    columns: u32,             // c= (display columns)
+    rows: u32,                // r= (display rows)
+    z_index: i32,             // z=
+    cursor_movement: u8,      // C= : 0 (move) or 1 (don't)
+    // Animation keys (Phase 3):
+    base_frame: u32,          // c= (overloaded in frame context)
+    edit_frame: u32,          // r= (overloaded in frame context)
+    compose_mode: u8,         // X= (overloaded: 0=blend, 1=overwrite)
+    bg_color: u32,            // Y= (overloaded: RGBA background)
+    gap_ms: i32,              // z= (overloaded: frame gap)
+    anim_state: u8,           // s= (overloaded: 1=stop, 2=loading, 3=run)
+    current_frame: u32,       // c= (overloaded: jump-to frame)
+    loops: u32,               // v= (overloaded: loop count)
+}
+```
+
+The parser is a **streaming state machine** (like sixel):
+1. `apc_start` → detect leading `G`, start accumulating
+2. `apc_put(byte)` → split at `;` → left side: parse key=value pairs; right side: accumulate base64 payload
+3. `apc_end` → finalize command, dispatch
+
+**Reference:** Ghostty's `graphics_command.zig` (clean single-char-key parser),
+WezTerm's `apc.rs` (Rust, functional style).
+
+**Dependencies (crate):**
+- `base64` — base64 decoding (already in ecosystem, check Cargo.lock)
+- `flate2` — zlib decompression for `o=z`
+- `png` or `image` — PNG decoding for `f=100`
+
+Prefer `png` crate over `image` for minimal footprint. WezTerm uses `image`
+(heavy, but they need it for animation blending). We can start with `png` and
+add `image` only if needed for Phase 3.
+
+### 1b. Chunked Transfer State
+
+Images larger than 4096 bytes arrive in multiple APC sequences with `m=1`
+(more) / `m=0` (last). Need per-image accumulation:
+
+```text
+// In Graphics struct:
+pub kitty_loading: Option<KittyLoadingImage>,
+
+struct KittyLoadingImage {
+    command: KittyCommand,      // from first chunk
+    payload: Vec<u8>,           // accumulated base64 bytes
+}
+```
+
+On `m=0`: decode full payload → decompress → decode format → `GraphicData`.
+
+Only **one** image can be loading at a time (per the spec). A new transmission
+with `m=1` cancels any in-progress load.
+
+### 1c. Payload Decode Pipeline
+
+```text
+base64 bytes ──► base64::decode() ──► Option<zlib::decompress()> ──► format dispatch
+                                                                          │
+                                              ┌───────────────────────────┤
+                                              ▼               ▼           ▼
+                                           f=24 (RGB)     f=32 (RGBA)  f=100 (PNG)
+                                              │               │           │
+                                              ▼               ▼           ▼
+                                          GraphicData { pixels, width, height, color_type }
+```
+
+For PNG: use `png` crate to decode → extract RGBA pixels, width, height.
+For raw formats: validate `s * v * bpp == len`.
+
+### 1d. Action Dispatch
+
+```text
+match command.action {
+    Action::Transmit           => store_image(command, pixels),
+    Action::TransmitAndDisplay => { store_image(...); place_image(...); },
+    Action::Query              => respond_ok_or_error(...),
+    Action::Display            => place_image(command),
+    Action::Delete             => delete_images(command),
+    // Phase 3:
+    Action::TransmitFrame      => load_animation_frame(command, pixels),
+    Action::AnimationControl   => control_animation(command),
+    Action::ComposeFrames      => compose_frames(command),
+}
+```
+
+### 1e. Image Storage
+
+```text
+// In Graphics struct:
+pub kitty_images: HashMap<u32, KittyImage>,
+
+struct KittyImage {
+    graphic_id: GraphicId,            // our internal monotonic ID
+    data: Option<GraphicData>,        // pixel data (for re-placement or animation)
+    placements: Vec<KittyPlacement>,  // active placements on screen
+    total_bytes: usize,               // for quota tracking
+}
+```
+
+**Storage quota:** 320 MiB total, LRU eviction of unreferenced images (matching
+kitty/ghostty/wezterm). Track total with an atomic counter.
+
+### 1f. Placement → Grid Cells
+
+`place_image()` adapts the kitty placement parameters to call the existing
+`insert_graphic()` or a thin wrapper around it:
+
+- Source rect (`x,y,w,h`) → crop `GraphicData` or pass subsection
+- Display size (`c,r` columns/rows) → scale to fit
+- Z-index → stored in `GraphicCell` (needs new field or separate overlay list)
+- `C=1` → skip cursor advancement after insert
+
+For the MVP, we can **ignore** z-index (everything renders above text, like
+sixel) and add z-ordering in a later phase.
+
+### 1g. Response Writing
+
+Kitty protocol requires responses written back to the PTY:
+
+```text
+ESC _Gi=<id>;OK ESC \              // success
+ESC _Gi=<id>;EINVAL:message ESC \  // error
+```
+
+Route through `Event::PtyWrite` (already exists for DSR and other responses).
+Respect `q=1` (suppress OK) and `q=2` (suppress all).
+
+### 1h. Delete Support
+
+MVP delete modes (matching what WezTerm actually implements):
+
+| `d=` | MVP? | Notes |
+|------|------|-------|
+| `a/A` | ✅ | Clear all visible placements |
+| `i/I` | ✅ | Delete by image ID |
+| `n/N` | ✅ | Delete by image number |
+| others | ❌ | Stub with no-op initially |
+
+**Files touched (Phase 1):**
+- `alacritty_terminal/src/graphics/kitty.rs` — NEW (~800-1200 LOC)
+- `alacritty_terminal/src/graphics/mod.rs` — add `KittyImage` storage, `kitty_loading` field
+- `alacritty_terminal/src/term/mod.rs` — wire APC hooks → kitty parser, dispatch
+- `alacritty_terminal/Cargo.toml` — add `base64`, `flate2`, `png` dependencies
+- `Cargo.toml` (workspace) — add new deps
+
+**Validation:**
+```sh
+# Basic test (requires kitty's kitten CLI or a compatible tool):
+kitty +kitten icat /path/to/image.png
+
+# Or manual escape sequence:
+python3 -c "
+import base64, sys
+data = open('test.png', 'rb').read()
+payload = base64.b64encode(data).decode()
+# Chunked: 4096 byte chunks
+chunks = [payload[i:i+4096] for i in range(0, len(payload), 4096)]
+for i, chunk in enumerate(chunks):
+    m = 1 if i < len(chunks) - 1 else 0
+    if i == 0:
+        sys.stdout.write(f'\033_Ga=T,f=100,m={m};{chunk}\033\\\\')
+    else:
+        sys.stdout.write(f'\033_Gm={m};{chunk}\033\\\\')
+sys.stdout.flush()
+"
+```
+
+**Estimated effort:** Medium-large. This is the bulk of the new code. The parser
+alone is ~400-600 lines, the state management another 400-600.
+
+---
+
+## Phase 2 — Correctness & Completeness
+
+Goal: pass the kitty graphics protocol test suite, handle edge cases.
+
+### 2a. Full Delete Support
+
+Implement remaining `d=` modes: by cursor position (`c/C`), by cell
+coordinates (`p/P`, `x/X`, `y/Y`), by z-index (`z/Z`), by ID range (`r/R`).
+
+Requires tracking which placements overlap which cells — the existing
+`GraphicCell` refs in the grid make position-based deletion O(visible area).
+
+### 2b. Image Number Support (`I=`)
+
+When `I=` is used without `i=`, the terminal auto-assigns an `i` and includes
+it in the response. Maintain a `HashMap<u32, u32>` mapping `image_number →
+newest_image_id`.
+
+### 2c. Source Rect & Scaling
+
+For `a=p` with `x,y,w,h` (source rect) and `c,r` (display columns/rows):
+- Extract sub-rectangle from stored image pixels
+- Scale to fit the target cell region (nearest-neighbor for speed, bilinear
+  for quality — make configurable or pick one)
+- Consider whether to do CPU-side scaling or upload full texture + use
+  UV coordinates in the shader (GPU-side is better for large images)
+
+**GPU-side approach (preferred):** Store the full texture. Pass source rect as
+UV coordinates to the fragment shader. The existing `graphics.f.glsl` already
+samples a texture — just adjust UVs. This avoids CPU pixel copies entirely.
+
+### 2d. Pixel Offsets & Sub-cell Positioning
+
+`X=` and `Y=` specify pixel offsets within the top-left cell. The existing
+`GraphicCell.offset_x/y` fields already handle this for sixel. Wire them up
+for kitty placements.
+
+### 2e. Cursor Movement Control
+
+`C=0` (default): move cursor to the row after the last row of the image.
+`C=1`: do not move cursor.
+
+The existing `insert_graphic()` always moves the cursor (sixel behavior).
+Add a parameter to control this.
+
+### 2f. Shared Memory & File Transmission
+
+- `t=f` (file): base64-decode the payload to get a file path, read the file.
+  **Security:** validate the path (no symlink attacks, no reading sensitive files).
+  Consider whether to support this at all — it's only useful locally.
+- `t=t` (temp file): same as file but delete after reading. Only delete if
+  path contains `tty-graphics-protocol` and is in a system temp directory.
+- `t=s` (shared memory): POSIX `shm_open` / Windows `OpenFileMappingW`.
+  Read bytes, then `shm_unlink`. Same security considerations.
+
+For an MVP, **only `t=d` (direct)** needs to work. File and shm can be added
+later since most tools (icat, etc.) fall back to direct when others aren't
+available.
+
+**Files touched (Phase 2):**
+- `alacritty_terminal/src/graphics/kitty.rs` — extend all action handlers
+- `alacritty_terminal/src/graphics/mod.rs` — source-rect UV support
+- `alacritty/src/renderer/graphics/` — shader UV changes if doing GPU-side crop
+- `alacritty/src/renderer/graphics/graphics.f.glsl` — UV rect uniforms
+
+**Validation:**
+- Kitty's own test script: `kitty +kitten icat --detect-support`
+- Manual tests for each delete mode
+- Test chunked transfer with images > 4KB
+
+**Estimated effort:** Medium. Mostly filling in stubs and edge cases.
+
+---
+
+## Phase 3 — Animation & Video
+
+Goal: animated images play in the terminal. Video streaming via tools like
+`mpv --vo=kitty` or `timg` works.
+
+### 3a. Multi-Frame Image Storage
+
+Extend `KittyImage` to hold multiple frames:
+
+```text
+struct KittyImage {
+    graphic_id: GraphicId,
+    frames: Vec<KittyFrame>,          // frame 0 = root image
+    placements: Vec<KittyPlacement>,
+    animation: AnimationState,
+    total_bytes: usize,
+}
+
+struct KittyFrame {
+    pixels: Vec<u8>,         // decoded RGBA pixels
+    width: u32,
+    height: u32,
+    gap_ms: i32,             // time to display (-ve = gapless/skip)
+    dirty: bool,             // needs GPU re-upload
+}
+
+struct AnimationState {
+    mode: AnimMode,          // Stopped, Loading, Running
+    current_frame: usize,    // index into frames[]
+    loops_remaining: u32,    // 0 = infinite, >0 = count down
+    last_advance: Instant,   // when current frame was displayed
+}
+
+enum AnimMode { Stopped, Loading, Running }
+```
+
+### 3b. Frame Loading (`a=f`)
+
+When `a=f` arrives:
+
+1. Decode payload same as Phase 1 (base64 → decompress → format decode)
+2. If `r=` (edit frame): modify existing frame's pixels in-place
+3. Else: create new frame, composite onto `c=` base frame (or transparent)
+4. Set `gap_ms` from `z=` parameter
+5. Mark frame as dirty for GPU upload
+
+**Composition** (needed for delta frames):
+- `X=0` (default): alpha blend source onto destination
+- `X=1`: overwrite destination with source
+
+Use the `image` crate's `imageops::overlay()` for alpha blending.
+This is where we upgrade from the `png` crate to `image`.
+
+**WezTerm reference:** `blit()` function in `kitty.rs` handles this with a
+`clip_view()` helper for the borrow checker. Their `Rgba8 → AnimRgba8`
+promotion pattern (upgrade a single-frame image to multi-frame on second
+frame arrival) is clean and worth following.
+
+### 3c. Animation Control (`a=a`)
+
+```text
+match command.anim_state {
+    1 => image.animation.mode = Stopped,
+    2 => image.animation.mode = Loading,   // play to end, wait for more
+    3 => image.animation.mode = Running,   // loop normally
+    _ => {}
+}
+if command.current_frame > 0 {
+    image.animation.current_frame = command.current_frame - 1;  // 1-based → 0-based
+}
+if command.loops > 0 {
+    image.animation.loops_remaining = command.loops;
+}
+// Per-frame gap update:
+if command.edit_frame > 0 {
+    image.frames[command.edit_frame - 1].gap_ms = command.gap_ms;
+}
+```
+
+### 3d. Frame Composition (`a=c`)
+
+Blit a rectangle from frame `r` onto frame `c` without new pixel data.
+Pure CPU-side operation on the stored frame buffers.
+
+### 3e. Animation Tick in the Render Loop
+
+The display draw loop needs to **advance animations** and **re-upload dirty frames**:
+
+```text
+// In display::draw(), after take_queues():
+
+let now = Instant::now();
+for image in graphics.kitty_images.values_mut() {
+    if image.animation.mode == Running || image.animation.mode == Loading {
+        let frame = &image.frames[image.animation.current_frame];
+        let gap = if frame.gap_ms > 0 { frame.gap_ms as u64 } else { 40 };
+
+        if now.duration_since(image.animation.last_advance) >= Duration::from_millis(gap) {
+            // Advance to next frame
+            let next = image.animation.current_frame + 1;
+            if next >= image.frames.len() {
+                if image.animation.mode == Loading {
+                    // Stay on last frame, wait for more data
+                } else if image.animation.loops_remaining == 0 {
+                    image.animation.current_frame = 0; // infinite loop
+                } else {
+                    image.animation.loops_remaining -= 1;
+                    if image.animation.loops_remaining > 0 {
+                        image.animation.current_frame = 0;
+                    } else {
+                        image.animation.mode = Stopped;
+                    }
+                }
+            } else {
+                // Skip gapless frames (gap < 0)
+                image.animation.current_frame = next;
+                while image.animation.current_frame < image.frames.len()
+                    && image.frames[image.animation.current_frame].gap_ms < 0
+                {
+                    image.animation.current_frame += 1;
+                }
+            }
+            image.animation.last_advance = now;
+
+            // Mark the GPU texture as needing re-upload with new frame's pixels
+            enqueue_texture_update(image);
+        }
+    }
+}
+```
+
+**Critical detail:** Animation requires **re-rendering even when no PTY input arrives**.
+The event loop needs a wake-up timer when animations are active. The existing
+`display::draw()` is driven by PTY events and window events — add a periodic
+tick (e.g., 16ms / 60fps) when at least one animation is running.
+
+**WezTerm reference:** They handle this in `glyphcache.rs` by checking frame
+duration on each draw call and clamping to `min_frame_duration`.
+
+### 3f. Efficient Texture Updates
+
+For animation, uploading the entire image every frame is wasteful. Options:
+
+1. **Full re-upload** (simplest): `glTexImage2D` with new pixel data each frame.
+   Fine for small images. WezTerm does this.
+2. **Sub-rect update**: `glTexSubImage2D` for delta frames that only change a
+   region. More efficient for large images with small changes.
+3. **Double-buffer**: maintain two GPU textures, swap on frame advance.
+
+Start with option 1 (full re-upload). Profile later.
+
+**Files touched (Phase 3):**
+- `alacritty_terminal/src/graphics/kitty.rs` — frame storage, composition, control
+- `alacritty_terminal/src/graphics/mod.rs` — animation state, timer integration
+- `alacritty/src/display/mod.rs` — animation tick in draw loop
+- `alacritty/src/event_loop.rs` or `alacritty/src/event.rs` — animation timer
+- `alacritty_terminal/Cargo.toml` — add `image` crate (for overlay/blend ops)
+
+**Validation:**
+```sh
+# Simple animated GIF via timg:
+timg --kitty animated.gif
+
+# mpv video output:
+mpv --vo=kitty --vo-kitty-use-shm=no video.mp4
+
+# Manual animation test:
+python3 tests/kitty_animation_test.py  # (we'll write this)
+```
+
+**Estimated effort:** Large. Frame composition and the render-loop timer are
+the trickiest parts.
+
+---
+
+## Phase 4 — Advanced Features (Stretch)
+
+### 4a. Unicode Placeholders (`U+10EEEE`)
+
+Virtual placements allow images inside tmux, vim, and other host programs.
+The image is placed by printing a special Unicode character with color attributes
+encoding the image/placement ID and diacritics encoding row/column.
+
+This requires:
+- Detecting `U+10EEEE` during cell rendering
+- Reading fg/underline color to extract image_id/placement_id
+- Reading diacritics to determine row/col within the image
+- Rendering the appropriate sub-tile of the image texture
+
+Lower priority — most direct use cases (icat, timg, mpv) don't need this.
+It's primarily for tmux passthrough and embedding in TUI apps.
+
+### 4b. Relative Placements
+
+`P=<parent_id>,Q=<parent_placement_id>` with `H,V` offsets. Placement
+lifetime is tied to parent. Max depth 8. Cycle detection required.
+
+Low priority — used mainly for annotations/overlays on images.
+
+### 4c. Z-Index Rendering
+
+The protocol supports `z=` for layering:
+- `z < INT32_MIN/2` → below non-default cell backgrounds
+- `z < 0` → below text
+- `z >= 0` → above text (default)
+
+Requires sorting placements by z during rendering and potentially multiple
+draw passes. Ghostty does 3 passes (below-bg, below-text, above-text).
+
+### 4d. Shared Memory & File Transmission
+
+Lower priority but needed for performance with large images. `t=s` (POSIX
+shared memory) avoids base64 overhead entirely. Important for video streaming
+over local connections.
+
+---
+
+## Dependency Summary
+
+| Crate | Phase | Purpose | Weight |
+|-------|-------|---------|--------|
+| `base64` | 1 | Decode APC payloads | Tiny |
+| `flate2` | 1 | Zlib decompression (`o=z`) | Small |
+| `png` | 1 | PNG decoding (`f=100`) | Small |
+| `image` | 3 | Frame composition (overlay/blend) | Medium |
+
+Check `Cargo.lock` — some of these may already be transitive dependencies.
+Prefer the lightest option at each phase.
+
+---
+
+## Task Breakdown
+
+### Phase 0: APC Routing
+- [ ] P0.1 — Fork/patch `vte-graphics` to add `apc_start/put/end` dispatch
+- [ ] P0.2 — Implement no-op `apc_*` methods in `term/mod.rs` Handler
+- [ ] P0.3 — Verify APC sequences reach the handler (printf test)
+
+### Phase 1: Static Images (MVP)
+- [ ] P1.1 — Create `graphics/kitty.rs` with key-value parser
+- [ ] P1.2 — Implement `KittyCommand` struct and streaming parser
+- [ ] P1.3 — Implement chunked transfer accumulation (`m=0/1`)
+- [ ] P1.4 — Implement payload decode (base64 → zlib → format → GraphicData)
+- [ ] P1.5 — Implement `a=t` (transmit/store) with `KittyImage` storage
+- [ ] P1.6 — Implement `a=T` (transmit + display) via `insert_graphic()`
+- [ ] P1.7 — Implement `a=q` (query) with response writing
+- [ ] P1.8 — Implement `a=p` (display previously stored image)
+- [ ] P1.9 — Implement `a=d` (delete) — `d=a`, `d=i`, `d=n` modes
+- [ ] P1.10 — Add `kitty_graphics` feature flag in config
+- [ ] P1.11 — End-to-end test: `kitty +kitten icat` displays an image
+
+### Phase 2: Correctness
+- [ ] P2.1 — Full delete mode support (`d=c/p/x/y/z/r` and uppercase)
+- [ ] P2.2 — Image number (`I=`) support with auto-ID assignment
+- [ ] P2.3 — Source rect display (UV coordinates in shader or CPU crop)
+- [ ] P2.4 — Display scaling (`c=`, `r=` columns/rows)
+- [ ] P2.5 — Pixel offset (`X=`, `Y=`) integration
+- [ ] P2.6 — Cursor movement control (`C=0/1`)
+- [ ] P2.7 — Storage quota enforcement (320 MiB cap, LRU eviction)
+- [ ] P2.8 — File transmission (`t=f`, `t=t`) with security checks
+- [ ] P2.9 — Shared memory transmission (`t=s`)
+
+### Phase 3: Animation & Video
+- [ ] P3.1 — Multi-frame `KittyImage` with `Vec<KittyFrame>`
+- [ ] P3.2 — Frame loading (`a=f`) with full & delta frames
+- [ ] P3.3 — Frame composition (alpha blend + overwrite via `image` crate)
+- [ ] P3.4 — Animation control (`a=a`) state machine
+- [ ] P3.5 — Frame composition command (`a=c`)
+- [ ] P3.6 — Animation tick in display draw loop
+- [ ] P3.7 — Event loop timer for animation-driven redraws
+- [ ] P3.8 — Efficient texture re-upload for frame changes
+- [ ] P3.9 — End-to-end test: animated GIF via timg, video via mpv
+
+### Phase 4: Advanced (Stretch)
+- [ ] P4.1 — Unicode placeholder support (`U+10EEEE`)
+- [ ] P4.2 — Relative placements (`P=`, `Q=`, `H`, `V`)
+- [ ] P4.3 — Z-index multi-pass rendering
+- [ ] P4.4 — Shared memory transmission optimization
+
+---
+
+## Testing Strategy
+
+Each phase gets **end-to-end tests** that exercise the full pipeline from escape
+sequence input to visible rendering, saving the developer from manual verification.
+
+```text
+tests/
+├── kitty_graphics/
+│   ├── test_parse.rs          # Unit tests for key-value parser
+│   ├── test_chunked.rs        # Chunked transfer reassembly
+│   ├── test_decode.rs         # base64 → zlib → PNG → pixels
+│   ├── test_storage.rs        # Image store, retrieve, quota, eviction
+│   ├── test_placement.rs      # Placement creation, source rect, scaling
+│   ├── test_delete.rs         # All delete modes
+│   ├── test_animation.rs      # Frame loading, composition, playback
+│   └── test_response.rs       # Response generation, quiet modes
+├── fixtures/
+│   ├── 1x1_red.png            # Minimal test image
+│   ├── 2x2_rgba.raw           # Raw RGBA pixels
+│   └── animated_2frame.bin    # Pre-encoded animation sequence
+└── integration/
+    ├── test_icat.sh           # Requires kitty CLI tools
+    └── test_timg.sh           # Requires timg
+```
+
+Tests must be **isolated** — no killing existing terminal processes, no writing
+to real PTY devices. Use the `alacritty_terminal::Term` struct directly with a
+mock event listener, feeding raw bytes and inspecting grid state.
+
+---
+
+## Risk Register
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| `vte-graphics` APC patch is complex | Blocks everything | The VTE state machine already parses APC; dispatch is ~20 lines. Low risk. |
+| Upstream Alacritty rejects kitty graphics | Fork diverges | Keep changes modular behind feature flag. Minimize changes to core code. |
+| Animation timer causes idle CPU burn | Battery drain | Only tick when animations are active. Use `request_redraw()` with delay, not busy-spin. |
+| Memory pressure from large images | OOM | Enforce 320 MiB quota from day one. Evict LRU. |
+| `image` crate bloats binary | Larger download | Only enable needed decoders (no JPEG, TIFF, etc. — just RGBA operations). |
+| Z-index rendering requires shader changes | Rendering regressions | Defer z-index to Phase 4. Default everything to above-text. |
+| Security of file/shm transmission | Path traversal, info leak | Phase 2 item. Validate paths strictly. Consider disabling by default. |

--- a/scripts/demo_kitty_graphics.sh
+++ b/scripts/demo_kitty_graphics.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Kitty Graphics Protocol — Real-World Demo ──────────────────────────
+#
+# Uses timg, chafa, and mpv to exercise the kitty graphics protocol
+# against our alacritty-kitty fork with real-world applications.
+#
+# Usage:
+#     # Build and launch the fork first:
+#     cd ~/src/wt/kitty/alacritty
+#     cargo build && ./target/debug/alacritty
+#
+#     # Then inside that terminal:
+#     bash scripts/demo_kitty_graphics.sh          # run all demos
+#     bash scripts/demo_kitty_graphics.sh static   # just static images
+#     bash scripts/demo_kitty_graphics.sh anim     # just animated GIF
+#     bash scripts/demo_kitty_graphics.sh video    # just video playback
+#     bash scripts/demo_kitty_graphics.sh scaling  # scaling comparisons
+#     bash scripts/demo_kitty_graphics.sh tools    # tool comparison grid
+#     bash scripts/demo_kitty_graphics.sh stress   # large/many images
+#
+# Prerequisites (brew install timg mpv chafa imagemagick):
+#     timg   — terminal image/video viewer with kitty support
+#     chafa  — terminal graphics with kitty support
+#     mpv    — media player with --vo=kitty
+#     magick — ImageMagick for generating test assets
+# ────────────────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ASSET_DIR="$(mktemp -d)"
+
+# Reset terminal modes that tools may enable and fail to clean up on exit.
+# Covers: mouse tracking (1000,1002,1003,1006,1015), bracketed paste (2004),
+# alternate screen (1049), application cursor keys (1).
+reset_term() {
+    printf '\033[?1000l\033[?1002l\033[?1003l\033[?1006l\033[?1015l'
+    printf '\033[?2004l'
+    printf '\033[?1049l'
+    printf '\033[?1l'
+}
+
+trap 'reset_term; rm -rf "$ASSET_DIR"' EXIT
+
+# ── Colors / helpers ───────────────────────────────────────────────────
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+DIM='\033[2m'
+RESET='\033[0m'
+
+banner() {
+    local width=62
+    echo
+    printf "${CYAN}╔"
+    printf '═%.0s' $(seq 1 $width)
+    printf "╗${RESET}\n"
+    printf "${CYAN}║${BOLD} %-${width}s${CYAN}║${RESET}\n" "$1"
+    if [[ -n "${2:-}" ]]; then
+        printf "${CYAN}║${DIM} %-${width}s${CYAN}║${RESET}\n" "$2"
+    fi
+    printf "${CYAN}╚"
+    printf '═%.0s' $(seq 1 $width)
+    printf "╝${RESET}\n"
+    echo
+}
+
+section() {
+    echo
+    printf "${YELLOW}── %s ──${RESET}\n" "$1"
+    echo
+}
+
+ok()   { printf "  ${GREEN}✓${RESET} %s\n" "$1"; }
+warn() { printf "  ${YELLOW}⚠${RESET} %s\n" "$1"; }
+fail() { printf "  ${RED}✗${RESET} %s\n" "$1"; }
+info() { printf "  ${DIM}%s${RESET}\n" "$1"; }
+
+pause() {
+    echo
+    printf "${DIM}  Press Enter to continue...${RESET}"
+    read -r
+    echo
+}
+
+check_tool() {
+    if command -v "$1" &>/dev/null; then
+        ok "$1 found: $(command -v "$1")"
+        return 0
+    else
+        fail "$1 not found — install with: brew install $1"
+        return 1
+    fi
+}
+
+# ── Asset Generation ───────────────────────────────────────────────────
+# Generate test images with ImageMagick so we don't depend on having
+# pictures lying around. Every asset is deterministic and disposable.
+
+generate_assets() {
+    section "Generating test assets in $ASSET_DIR"
+
+    # 1. Gradient PNG (256x256) — good for scaling tests.
+    magick -size 256x256 gradient:red-blue "$ASSET_DIR/gradient.png"
+    ok "gradient.png (256×256 red→blue)"
+
+    # 2. Photo-like: plasma fractal (512x384) — exercises PNG decode well.
+    magick -size 512x384 plasma:fractal "$ASSET_DIR/plasma.png"
+    ok "plasma.png (512×384 fractal)"
+
+    # 3. Tiny icon (16x16) — tests small image handling.
+    magick -size 16x16 xc:none \
+        -fill '#FF6600' -draw "circle 7,7 7,1" \
+        "$ASSET_DIR/icon16.png"
+    ok "icon16.png (16×16 circle)"
+
+    # 4. Wide banner (800x100) — tests horizontal scroll / clipping.
+    magick -size 800x100 gradient:cyan-magenta "$ASSET_DIR/banner.png"
+    ok "banner.png (800×100 wide)"
+
+    # 5. Tall strip (100x600) — tests vertical clipping.
+    magick -size 100x600 gradient:yellow-green "$ASSET_DIR/tall.png"
+    ok "tall.png (100×600 tall)"
+
+    # 6. Animated GIF — 8 frames, color cycling, 150ms per frame.
+    local frames=()
+    for i in $(seq 0 7); do
+        local hue=$((i * 45))
+        magick -size 128x128 "xc:hsl($hue,100%,50%)" \
+            "$ASSET_DIR/frame_$i.png"
+        frames+=("$ASSET_DIR/frame_$i.png")
+    done
+    magick -delay 15 -loop 0 "${frames[@]}" "$ASSET_DIR/anim.gif"
+    rm -f "$ASSET_DIR"/frame_*.png
+    ok "anim.gif (128×128, 8 frames, 150ms/frame)"
+
+    # 7. RGBA with transparency (checkerboard + semi-transparent overlay).
+    magick -size 128x128 pattern:checkerboard \
+        \( -size 128x128 xc:'rgba(255,0,0,0.5)' \) \
+        -composite "$ASSET_DIR/alpha.png"
+    ok "alpha.png (128×128 with transparency)"
+
+    # 8. Short video clip (3 seconds) for mpv test.
+    #    Uses testsrc2 (always available) — drawtext is not in brew ffmpeg.
+    if command -v ffmpeg &>/dev/null; then
+        if ffmpeg -y -loglevel error \
+            -f lavfi -i "testsrc2=s=320x240:d=3:rate=30" \
+            -c:v libx264 -pix_fmt yuv420p -t 3 \
+            "$ASSET_DIR/clip.mp4" 2>/dev/null; then
+            ok "clip.mp4 (320×240, 3s test pattern)"
+        else
+            warn "ffmpeg failed to generate clip.mp4 — skipping video asset"
+        fi
+    else
+        warn "ffmpeg not found — skipping video asset"
+    fi
+
+    echo
+}
+
+# ── Demo: Static Images ───────────────────────────────────────────────
+
+demo_static() {
+    banner "Static Image Display" "timg -p kitty — tests transmit+display, PNG decode, RGBA"
+
+    section "timg: gradient (256×256)"
+    timg -p kitty -g 40x20 "$ASSET_DIR/gradient.png"; reset_term
+    ok "gradient.png displayed via timg -p kitty"
+
+    section "timg: plasma fractal (512×384)"
+    timg -p kitty -g 60x20 "$ASSET_DIR/plasma.png"; reset_term
+    ok "plasma.png displayed — exercises chunked transfer for larger images"
+
+    section "timg: tiny icon (16×16)"
+    timg -p kitty "$ASSET_DIR/icon16.png"; reset_term
+    ok "icon16.png — small image, minimal cells"
+
+    section "timg: alpha transparency"
+    timg -p kitty -g 30x15 "$ASSET_DIR/alpha.png"; reset_term
+    ok "alpha.png — RGBA with semi-transparent red overlay"
+
+    section "chafa: plasma (kitty mode)"
+    chafa -f kitty --size 60x20 "$ASSET_DIR/plasma.png"; reset_term
+    ok "plasma.png via chafa -f kitty"
+
+    section "chafa: gradient (kitty mode)"
+    chafa -f kitty --size 40x20 "$ASSET_DIR/gradient.png"; reset_term
+    ok "gradient.png via chafa -f kitty"
+
+    pause
+}
+
+# ── Demo: Scaling Comparison ──────────────────────────────────────────
+
+demo_scaling() {
+    banner "Scaling Test" "Same image at multiple sizes — cell-based scaling (c=/r=)"
+
+    local img="$ASSET_DIR/plasma.png"
+
+    section "timg: thumbnail (15 cols)"
+    timg -p kitty -g 15x8 "$img"; reset_term
+    ok "15×8 cells (small thumbnail)"
+
+    section "timg: medium (40 cols)"
+    timg -p kitty -g 40x20 "$img"; reset_term
+    ok "40×20 cells (medium)"
+
+    section "timg: large (70 cols)"
+    timg -p kitty -g 70x25 "$img"; reset_term
+    ok "70×25 cells (large)"
+
+    section "timg: wide banner (full width)"
+    timg -p kitty "$ASSET_DIR/banner.png"; reset_term
+    ok "banner.png — tests wide image clipping"
+
+    section "timg: tall strip (capped height)"
+    timg -p kitty -g 15x20 "$ASSET_DIR/tall.png"; reset_term
+    ok "tall.png at 15×20 — tests tall image scaling"
+
+    section "chafa: side-by-side sizes"
+    printf "  "
+    chafa -f kitty --size 10x5 "$img"; reset_term
+    printf "  "
+    chafa -f kitty --size 20x10 "$img"; reset_term
+    printf "  "
+    chafa -f kitty --size 30x15 "$img"; reset_term
+    echo
+    ok "chafa at 10×5, 20×10, 30×15 — visual scaling comparison"
+
+    pause
+}
+
+# ── Demo: Animated GIF ────────────────────────────────────────────────
+
+demo_anim() {
+    banner "Animated GIF" "timg handles frame loops itself — tests rapid transmit+display"
+
+    section "timg: animated GIF (8 frames, 3 loops)"
+    info "Playing 3 loops of color-cycling animation..."
+    info "Each frame is a full transmit+display — exercises the hot path."
+    echo
+    timg -p kitty --loops=3 -g 30x15 "$ASSET_DIR/anim.gif"; reset_term
+    ok "anim.gif played 3 loops via timg"
+    info "(timg sends each frame as a new image — NOT kitty animation protocol)"
+
+    if command -v chafa &>/dev/null; then
+        section "chafa: animated GIF"
+        info "chafa plays GIFs natively in kitty mode too."
+        echo
+        chafa -f kitty --size 30x15 --duration 3 "$ASSET_DIR/anim.gif" || true; reset_term
+        ok "anim.gif via chafa (duration-limited)"
+    fi
+
+    pause
+}
+
+# ── Demo: Video Playback ─────────────────────────────────────────────
+
+demo_video() {
+    banner "Video Playback" "mpv --vo=kitty and timg video — real-time frame streaming"
+
+    warn "⚠  Video playback sends images at high frame rates."
+    warn "   This can trigger segfaults in the graphics rendering pipeline"
+    warn "   (a pre-existing issue in the sixel GPU upload path, not kitty-specific)."
+    echo
+    printf "${DIM}  Run video demos? [y/N] ${RESET}"
+    read -r answer
+    if [[ "${answer,,}" != "y" ]]; then
+        info "Skipped video demos."
+        return
+    fi
+
+    if [[ ! -f "$ASSET_DIR/clip.mp4" ]]; then
+        warn "clip.mp4 not generated (ffmpeg missing?) — skipping video demos"
+        return
+    fi
+
+    section "timg: video playback (3s clip)"
+    info "timg decodes video frames and sends each as a kitty image."
+    info "This is the heaviest real-world kitty graphics workload."
+    echo
+    timg -p kitty -g 40x20 --loops=1 -V "$ASSET_DIR/clip.mp4" || warn "timg exited unexpectedly"; reset_term
+    ok "clip.mp4 played via timg -V"
+
+    section "mpv: video playback with --vo=kitty (3s clip)"
+    info "mpv has native kitty graphics protocol output."
+    info "This tests the full protocol under a demanding client."
+    echo
+    # mpv --vo=kitty uses the kitty protocol directly.
+    # --really-quiet suppresses mpv's status line.
+    # --no-terminal prevents mpv from grabbing the terminal.
+    mpv --vo=kitty --really-quiet --no-input-terminal \
+        --loop-file=no --frames=90 \
+        "$ASSET_DIR/clip.mp4" 2>/dev/null || warn "mpv exited (may need terminal focus)"; reset_term
+    ok "clip.mp4 played via mpv --vo=kitty"
+
+    pause
+}
+
+# ── Demo: Tool Comparison ─────────────────────────────────────────────
+
+demo_tools() {
+    banner "Tool Comparison" "Same image rendered by timg vs chafa in kitty mode"
+
+    local img="$ASSET_DIR/plasma.png"
+    local size="40x15"
+
+    section "timg -p kitty (--grid ${size})"
+    timg -p kitty -g "$size" "$img"; reset_term
+
+    section "chafa -f kitty (--size ${size})"
+    chafa -f kitty --size "$size" "$img"; reset_term
+
+    info "Both should look similar. Differences come from:"
+    info "  • How each tool maps pixels to cells"
+    info "  • Scaling algorithm (timg vs chafa internals)"
+    info "  • Whether they use c=/r= (cell scaling) vs pre-scaling pixels"
+
+    pause
+}
+
+# ── Demo: Stress Test ─────────────────────────────────────────────────
+
+demo_stress() {
+    banner "Stress Test" "Many images, large images, rapid display"
+
+    section "Rapid-fire: 20 small images in sequence"
+    info "Tests image ID cycling, memory quota, cleanup."
+    for i in $(seq 1 20); do
+        local hue=$(( (i * 18) % 360 ))
+        magick -size 32x32 "xc:hsl($hue,80%,60%)" "$ASSET_DIR/stress_$i.png"
+    done
+    for i in $(seq 1 20); do
+        timg -p kitty -g 4x2 "$ASSET_DIR/stress_$i.png"; reset_term
+        printf " "
+    done
+    echo
+    ok "20 images displayed in rapid succession"
+
+    section "Large image: 1920×1080 (full HD)"
+    info "Tests chunked transfer with large payloads."
+    magick -size 1920x1080 plasma:fractal "$ASSET_DIR/large.png" 2>/dev/null
+    ok "Generated 1920×1080 plasma"
+    timg -p kitty -g 70x25 "$ASSET_DIR/large.png"; reset_term
+    ok "Displayed at 70×25 cells — large image scaled down"
+
+    section "Grid of images"
+    info "Multiple images sharing the terminal grid."
+    for i in $(seq 1 6); do
+        timg -p kitty -g 12x6 "$ASSET_DIR/gradient.png"; reset_term
+    done
+    ok "6 copies of gradient in grid layout"
+
+    pause
+}
+
+# ── Demo: File Medium ─────────────────────────────────────────────────
+
+demo_file_medium() {
+    banner "File Medium (t=f)" "timg can use file transmission when available"
+
+    section "timg with explicit kitty protocol"
+    info "Displaying a local file — timg may use t=f (file medium)"
+    info "or t=d (direct) depending on its heuristics."
+    info "Check alacritty debug log for: [kitty] command: ... medium=File"
+    echo
+    timg -p kitty -g 40x20 "$ASSET_DIR/plasma.png"; reset_term
+    ok "Image displayed — check -vv log for medium used"
+    info "Run alacritty with RUST_LOG=debug to see medium in log output."
+
+    pause
+}
+
+# ── Main ──────────────────────────────────────────────────────────────
+
+main() {
+    banner "Kitty Graphics Protocol — Real-World Demo" \
+           "Testing alacritty-kitty with timg, chafa, mpv"
+
+    section "Checking prerequisites"
+    local missing=0
+    check_tool timg   || missing=$((missing + 1))
+    check_tool chafa  || missing=$((missing + 1))
+    check_tool mpv    || missing=$((missing + 1))
+    check_tool magick || missing=$((missing + 1))
+    echo
+
+    if [[ $missing -gt 0 ]]; then
+        warn "$missing tool(s) missing. Install with:"
+        info "  brew install timg chafa mpv imagemagick"
+        echo
+        info "Continuing with available tools..."
+        echo
+    fi
+
+    if ! command -v magick &>/dev/null; then
+        fail "ImageMagick (magick) is required to generate test assets."
+        fail "Install with: brew install imagemagick"
+        exit 1
+    fi
+
+    generate_assets
+
+    local cmd="${1:-all}"
+    case "$cmd" in
+        static)      demo_static ;;
+        scaling)     demo_scaling ;;
+        anim)        demo_anim ;;
+        video)       demo_video ;;
+        tools)       demo_tools ;;
+        stress)      demo_stress ;;
+        file_medium) demo_file_medium ;;
+        all)
+            demo_static
+            demo_scaling
+            demo_anim
+            demo_video
+            demo_tools
+            demo_stress
+            ;;
+        *)
+            echo "Usage: $0 [static|scaling|anim|video|tools|stress|file_medium|all]"
+            exit 1
+            ;;
+    esac
+
+    banner "Demo Complete" \
+           "If you saw images above, the kitty graphics protocol is working!"
+
+    info "For debugging, relaunch alacritty with:"
+    info "  RUST_LOG=debug ./target/debug/alacritty 2>&1 | grep kitty"
+    echo
+}
+
+main "$@"

--- a/scripts/test_kitty_graphics.py
+++ b/scripts/test_kitty_graphics.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.12"
+# ///
+"""
+Manual test script for kitty graphics protocol support.
+
+Usage:
+    # First, build and launch the alacritty fork:
+    cd kitty/alacritty
+    cargo build && ./target/debug/alacritty
+
+    # Then, inside that alacritty window, run:
+    uv run scripts/test_kitty_graphics.py
+
+    # Or run individual tests:
+    python3 scripts/test_kitty_graphics.py query
+    python3 scripts/test_kitty_graphics.py png
+    python3 scripts/test_kitty_graphics.py rgba
+    python3 scripts/test_kitty_graphics.py rgb
+    python3 scripts/test_kitty_graphics.py chunked
+    python3 scripts/test_kitty_graphics.py delete
+    python3 scripts/test_kitty_graphics.py zlib
+    python3 scripts/test_kitty_graphics.py file <path_to_image.png>
+
+See: https://sw.kovidgoyal.net/kitty/graphics-protocol/
+"""
+
+import base64
+import io
+import os
+import select
+import struct
+import sys
+import termios
+import tty
+import zlib
+
+
+def drain_responses(timeout: float = 0.1) -> list[str]:
+    """Read and discard any pending APC responses from stdin.
+
+    When we send kitty graphics commands, the terminal writes responses
+    back to the PTY (e.g. ESC _Gi=1;OK ESC \\). If we don't consume
+    them, they leak into the shell prompt as garbage text.
+
+    Returns the raw response strings for debugging.
+    """
+    responses = []
+    fd = sys.stdin.fileno()
+
+    # Save terminal state and switch to raw mode so we can read
+    # without waiting for Enter.
+    old_settings = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        buf = bytearray()
+        while True:
+            ready, _, _ = select.select([fd], [], [], timeout)
+            if not ready:
+                break
+            chunk = os.read(fd, 4096)
+            if not chunk:
+                break
+            buf.extend(chunk)
+        if buf:
+            responses.append(buf.decode("utf-8", errors="replace"))
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+
+    return responses
+
+
+def write_apc(payload: str, expect_response: bool = True) -> list[str]:
+    """Write a kitty graphics APC sequence to stdout.
+
+    If expect_response is True, drains the PTY response so it doesn't
+    leak into the shell prompt.
+    """
+    sys.stdout.write(f"\033_G{payload}\033\\")
+    sys.stdout.flush()
+    if expect_response:
+        return drain_responses()
+    return []
+
+
+def write_chunked(key_values: str, data: bytes, chunk_size: int = 4096) -> list[str]:
+    """Write image data in chunks per the kitty protocol."""
+    encoded = base64.standard_b64encode(data).decode("ascii")
+    chunks = [encoded[i : i + chunk_size] for i in range(0, len(encoded), chunk_size)]
+
+    if not chunks:
+        return write_apc(f"{key_values},m=0;")
+
+    for i, chunk in enumerate(chunks):
+        is_last = i == len(chunks) - 1
+        m = 0 if is_last else 1
+        if i == 0:
+            # Intermediate chunks don't get responses; only drain on last.
+            write_apc(f"{key_values},m={m};{chunk}", expect_response=is_last)
+        else:
+            write_apc(f"m={m};{chunk}", expect_response=is_last)
+    return []
+
+
+def make_solid_rgba(width: int, height: int, r: int, g: int, b: int, a: int = 255) -> bytes:
+    """Create a solid-color RGBA image as raw bytes."""
+    pixel = bytes([r, g, b, a])
+    return pixel * (width * height)
+
+
+def make_gradient_rgba(width: int, height: int) -> bytes:
+    """Create an RGBA gradient image (red→blue horizontally, green vertically)."""
+    pixels = bytearray()
+    for y in range(height):
+        for x in range(width):
+            r = int(255 * x / max(width - 1, 1))
+            g = int(255 * y / max(height - 1, 1))
+            b = 255 - r
+            pixels.extend([r, g, b, 255])
+    return bytes(pixels)
+
+
+def make_checkerboard_rgba(width: int, height: int, sq: int = 8) -> bytes:
+    """Create an RGBA checkerboard pattern."""
+    pixels = bytearray()
+    for y in range(height):
+        for x in range(width):
+            if ((x // sq) + (y // sq)) % 2 == 0:
+                pixels.extend([200, 200, 200, 255])
+            else:
+                pixels.extend([50, 50, 50, 255])
+    return bytes(pixels)
+
+
+def make_test_png(width: int, height: int) -> bytes:
+    """Create a minimal PNG image in memory (no external deps)."""
+    # We'll build a valid PNG by hand: IHDR, IDAT, IEND.
+    # Using uncompressed deflate blocks for simplicity.
+
+    def png_chunk(chunk_type: bytes, data: bytes) -> bytes:
+        chunk = chunk_type + data
+        crc = struct.pack(">I", zlib.crc32(chunk) & 0xFFFFFFFF)
+        return struct.pack(">I", len(data)) + chunk + crc
+
+    # PNG signature
+    sig = b"\x89PNG\r\n\x1a\n"
+
+    # IHDR: width, height, bit_depth=8, color_type=2 (RGB), compression=0, filter=0, interlace=0
+    ihdr_data = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    ihdr = png_chunk(b"IHDR", ihdr_data)
+
+    # Image data: each row has a filter byte (0=None) followed by RGB pixels
+    raw_rows = bytearray()
+    for y in range(height):
+        raw_rows.append(0)  # filter: None
+        for x in range(width):
+            r = int(255 * x / max(width - 1, 1))
+            g = int(255 * y / max(height - 1, 1))
+            b = 128
+            raw_rows.extend([r, g, b])
+
+    compressed = zlib.compress(bytes(raw_rows))
+    idat = png_chunk(b"IDAT", compressed)
+
+    iend = png_chunk(b"IEND", b"")
+
+    return sig + ihdr + idat + iend
+
+
+# ── Test Functions ──────────────────────────────────────────────────────
+
+
+def test_query():
+    """Test 1: Query protocol support (a=q).
+
+    Expected: Terminal should respond with ESC _Gi=1;OK ESC \\
+    You can check with: cat -v  (then paste the query, you should see a response)
+    """
+    print("═" * 60)
+    print("TEST: Query protocol support (a=q)")
+    print("  Sending query... (response goes to PTY input)")
+    print("  Expected response: \\e_Gi=1;OK\\e\\\\")
+    print("═" * 60)
+
+    # Query with a tiny 1x1 PNG to test format support.
+    png_data = make_test_png(1, 1)
+    encoded = base64.standard_b64encode(png_data).decode("ascii")
+    responses = write_apc(f"a=q,i=1,f=100;{encoded}")
+    if responses:
+        raw = responses[0]
+        if "OK" in raw:
+            print(f"  ✓ Query sent — got OK response")
+        else:
+            print(f"  ✗ Query sent — unexpected response: {raw!r}")
+    else:
+        print("  ⚠ Query sent — no response received (timeout)")
+    print()
+
+
+def test_rgba():
+    """Test 2: Display a raw RGBA image (f=32, a=T)."""
+    print("═" * 60)
+    print("TEST: Raw RGBA image (32x32 gradient)")
+    print("═" * 60)
+
+    width, height = 32, 32
+    pixels = make_gradient_rgba(width, height)
+    responses = write_chunked(f"a=T,f=32,s={width},v={height},i=10", pixels)
+    print("  ✓ Sent 32x32 RGBA gradient (image id=10)")
+    print("  You should see a small colorful square above.\n")
+
+
+def test_rgb():
+    """Test 3: Display a raw RGB image (f=24, a=T)."""
+    print("═" * 60)
+    print("TEST: Raw RGB image (24x24 solid red)")
+    print("═" * 60)
+
+    width, height = 24, 24
+    # RGB = 3 bytes per pixel
+    pixel = bytes([255, 0, 0])
+    pixels = pixel * (width * height)
+    responses = write_chunked(f"a=T,f=24,s={width},v={height},i=11", pixels)
+    print("  ✓ Sent 24x24 solid red RGB (image id=11)")
+    print("  You should see a small red square above.\n")
+
+
+def test_png():
+    """Test 4: Display a PNG image (f=100, a=T)."""
+    print("═" * 60)
+    print("TEST: PNG image (64x32 gradient)")
+    print("═" * 60)
+
+    png_data = make_test_png(64, 32)
+    responses = write_chunked("a=T,f=100,i=12", png_data)
+    print(f"  ✓ Sent 64x32 PNG ({len(png_data)} bytes, image id=12)")
+    print("  You should see a gradient rectangle above.\n")
+
+
+def test_chunked():
+    """Test 5: Chunked transfer with small chunk size."""
+    print("═" * 60)
+    print("TEST: Chunked transfer (48x48 checkerboard, 256-byte chunks)")
+    print("═" * 60)
+
+    width, height = 48, 48
+    pixels = make_checkerboard_rgba(width, height)
+    # Use very small chunks to exercise the chunked code path.
+    responses = write_chunked(f"a=T,f=32,s={width},v={height},i=13", pixels, chunk_size=256)
+    print(f"  ✓ Sent 48x48 checkerboard in 256-byte chunks (image id=13)")
+    print("  You should see a checkerboard pattern above.\n")
+
+
+def test_zlib():
+    """Test 6: Zlib-compressed RGBA image (o=z)."""
+    print("═" * 60)
+    print("TEST: Zlib-compressed RGBA image (32x32 solid blue)")
+    print("═" * 60)
+
+    width, height = 32, 32
+    pixels = make_solid_rgba(width, height, 0, 0, 255)
+    compressed = zlib.compress(pixels)
+    responses = write_chunked(f"a=T,f=32,o=z,s={width},v={height},i=14", compressed)
+    print(f"  ✓ Sent 32x32 blue (compressed {len(pixels)}→{len(compressed)} bytes, image id=14)")
+    print("  You should see a solid blue square above.\n")
+
+
+def test_transmit_then_display():
+    """Test 7: Transmit (a=t) then display (a=p) separately."""
+    print("═" * 60)
+    print("TEST: Separate transmit (a=t) then display (a=p)")
+    print("═" * 60)
+
+    width, height = 32, 32
+    pixels = make_solid_rgba(width, height, 0, 200, 0)
+    responses = write_chunked(f"a=t,f=32,s={width},v={height},i=15", pixels)
+    print("  ✓ Transmitted 32x32 green (image id=15) — no display yet")
+
+    # Now display it.
+    responses = write_apc("a=p,i=15")
+    print("  ✓ Displayed image id=15")
+    print("  You should see a solid green square above.\n")
+
+
+def test_delete():
+    """Test 8: Delete operations."""
+    print("═" * 60)
+    print("TEST: Delete images")
+    print("═" * 60)
+
+    # Place a small image.
+    width, height = 16, 16
+    pixels = make_solid_rgba(width, height, 255, 255, 0)
+    responses = write_chunked(f"a=T,f=32,s={width},v={height},i=20", pixels)
+    print("  ✓ Placed 16x16 yellow square (image id=20)")
+
+    # Delete by ID — delete commands don't produce responses.
+    write_apc("a=d,d=i,i=20", expect_response=False)
+    print("  ✓ Deleted image id=20")
+    print("  The yellow square may still be visible (cell content cleared on next redraw).\n")
+
+
+def test_file(path: str):
+    """Test 9: Display a PNG file from disk."""
+    print("═" * 60)
+    print(f"TEST: Display PNG file: {path}")
+    print("═" * 60)
+
+    if not os.path.exists(path):
+        print(f"  ✗ File not found: {path}")
+        return
+
+    with open(path, "rb") as f:
+        data = f.read()
+
+    responses = write_chunked("a=T,f=100,i=30", data)
+    print(f"  ✓ Sent {len(data)} bytes from {path} (image id=30)")
+    print("  You should see the image above.\n")
+
+
+def test_quiet_modes():
+    """Test 10: Quiet mode (q=1 suppresses OK, q=2 suppresses all)."""
+    print("═" * 60)
+    print("TEST: Quiet modes (q=0, q=1, q=2)")
+    print("═" * 60)
+
+    png_data = make_test_png(1, 1)
+    encoded = base64.standard_b64encode(png_data).decode("ascii")
+
+    r0 = write_apc(f"a=q,q=0,i=40,f=100;{encoded}")
+    got0 = "OK" in r0[0] if r0 else False
+    print(f"  {'✓' if got0 else '⚠'} q=0 query — {'got OK' if got0 else 'no response'}")
+
+    r1 = write_apc(f"a=q,q=1,i=41,f=100;{encoded}")
+    got1 = len(r1) == 0 or not any("OK" in r for r in r1)
+    print(f"  {'✓' if got1 else '✗'} q=1 query — {'OK suppressed' if got1 else 'got unexpected response'}")
+
+    r2 = write_apc(f"a=q,q=2,i=42,f=100;{encoded}")
+    got2 = len(r2) == 0 or not any("OK" in r for r in r2)
+    print(f"  {'✓' if got2 else '✗'} q=2 query — {'all suppressed' if got2 else 'got unexpected response'}")
+    print()
+
+
+def test_cursor_no_move():
+    """Test 11: C=1 (don't move cursor after placement)."""
+    print("═" * 60)
+    print("TEST: Cursor movement control (C=1)")
+    print("═" * 60)
+
+    width, height = 16, 16
+    pixels = make_solid_rgba(width, height, 200, 100, 50)
+    encoded = base64.standard_b64encode(pixels).decode("ascii")
+
+    # Place with C=1 — cursor should NOT move.
+    responses = write_chunked(f"a=T,f=32,s={width},v={height},i=50,C=1", pixels)
+    print("  ✓ Placed 16x16 image with C=1 (cursor should not move)")
+    print("  This text should appear at the same line as the image.\n")
+
+
+def run_all():
+    """Run all tests in sequence."""
+    print()
+    print("╔══════════════════════════════════════════════════════════╗")
+    print("║       Kitty Graphics Protocol — Manual Test Suite       ║")
+    print("║                                                         ║")
+    print("║  Run inside the alacritty-kitty fork to test graphics.  ║")
+    print("║  Build: cargo build                                     ║")
+    print("║  Launch: ./target/debug/alacritty                       ║")
+    print("╚══════════════════════════════════════════════════════════╝")
+    print()
+
+    test_query()
+    test_rgba()
+    test_rgb()
+    test_png()
+    test_chunked()
+    test_zlib()
+    test_transmit_then_display()
+    test_delete()
+    test_quiet_modes()
+    test_cursor_no_move()
+
+    print("═" * 60)
+    print("ALL TESTS SENT.")
+    print()
+    print("If you see colored squares above, the protocol is working!")
+    print("If you only see text, check the debug log output:")
+    print("  RUST_LOG=debug ./target/debug/alacritty 2>&1 | grep kitty")
+    print("═" * 60)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        run_all()
+    else:
+        cmd = sys.argv[1]
+        dispatch = {
+            "query": test_query,
+            "rgba": test_rgba,
+            "rgb": test_rgb,
+            "png": test_png,
+            "chunked": test_chunked,
+            "zlib": test_zlib,
+            "transmit": test_transmit_then_display,
+            "delete": test_delete,
+            "quiet": test_quiet_modes,
+            "cursor": test_cursor_no_move,
+            "all": run_all,
+        }
+
+        if cmd == "file":
+            if len(sys.argv) < 3:
+                print("Usage: test_kitty_graphics.py file <path_to_image.png>")
+                sys.exit(1)
+            test_file(sys.argv[2])
+        elif cmd in dispatch:
+            dispatch[cmd]()
+        else:
+            print(f"Unknown test: {cmd}")
+            print(f"Available: {', '.join(sorted(dispatch.keys()))}, file <path>")
+            sys.exit(1)

--- a/scripts/test_kitty_graphics.py
+++ b/scripts/test_kitty_graphics.py
@@ -13,26 +13,35 @@ Usage:
     # Then, inside that alacritty window, run:
     uv run scripts/test_kitty_graphics.py
 
-    # Or run individual tests:
-    python3 scripts/test_kitty_graphics.py query
-    python3 scripts/test_kitty_graphics.py png
-    python3 scripts/test_kitty_graphics.py rgba
-    python3 scripts/test_kitty_graphics.py rgb
-    python3 scripts/test_kitty_graphics.py chunked
-    python3 scripts/test_kitty_graphics.py delete
-    python3 scripts/test_kitty_graphics.py zlib
-    python3 scripts/test_kitty_graphics.py file <path_to_image.png>
+    # Or run individual tests / groups:
+    uv run scripts/test_kitty_graphics.py query
+    uv run scripts/test_kitty_graphics.py png
+    uv run scripts/test_kitty_graphics.py phase1      # all Phase 1 tests
+    uv run scripts/test_kitty_graphics.py phase2      # all Phase 2 tests
+    uv run scripts/test_kitty_graphics.py file_medium
+    uv run scripts/test_kitty_graphics.py tempfile_medium
+    uv run scripts/test_kitty_graphics.py shm_medium
+    uv run scripts/test_kitty_graphics.py delete_modes
+    uv run scripts/test_kitty_graphics.py scaling
+    uv run scripts/test_kitty_graphics.py offsets
+    uv run scripts/test_kitty_graphics.py animation
+    uv run scripts/test_kitty_graphics.py file <path_to_image.png>
 
 See: https://sw.kovidgoyal.net/kitty/graphics-protocol/
 """
 
 import base64
+import ctypes
+import ctypes.util
 import io
+import mmap
 import os
 import select
 import struct
 import sys
+import tempfile
 import termios
+import time
 import tty
 import zlib
 
@@ -302,7 +311,7 @@ def test_delete():
 
 
 def test_file(path: str):
-    """Test 9: Display a PNG file from disk."""
+    """Test 9: Display a PNG file from disk (user-supplied path)."""
     print("═" * 60)
     print(f"TEST: Display PNG file: {path}")
     print("═" * 60)
@@ -358,6 +367,548 @@ def test_cursor_no_move():
     print("  This text should appear at the same line as the image.\n")
 
 
+# ── Phase 2: File & Shared Memory Transmission ─────────────────────────
+
+
+def test_file_medium():
+    """Phase 2A: Transmit+display via file medium (t=f).
+
+    Writes a raw RGBA image to a temp file, then tells the terminal to
+    read it via the base64-encoded path.
+    """
+    print("═" * 60)
+    print("TEST: File medium (t=f) — 32x32 gradient via filesystem")
+    print("═" * 60)
+
+    width, height = 32, 32
+    pixels = make_gradient_rgba(width, height)
+
+    with tempfile.NamedTemporaryFile(suffix=".rgba", delete=False) as f:
+        f.write(pixels)
+        tmp_path = f.name
+
+    path_b64 = base64.standard_b64encode(tmp_path.encode()).decode("ascii")
+    responses = write_apc(f"a=T,t=f,f=32,s={width},v={height},i=60;{path_b64}")
+
+    if responses and "OK" in responses[0]:
+        print(f"  ✓ File medium — terminal read {tmp_path}")
+    elif responses:
+        print(f"  ⚠ Response: {responses[0]!r}")
+    else:
+        print(f"  ✓ Sent file medium command (path={tmp_path})")
+
+    print("  You should see a 32x32 gradient above.")
+    # Don't delete — terminal may still need it. It's in $TMPDIR anyway.
+    print(f"  (temp file left at {tmp_path})\n")
+
+
+def test_tempfile_medium():
+    """Phase 2A: Transmit+display via temp file medium (t=t).
+
+    The payload is a base64-encoded *relative* path under the system
+    temp directory. The terminal should delete the file after reading.
+    """
+    print("═" * 60)
+    print("TEST: Temp file medium (t=t) — 24x24 solid magenta")
+    print("═" * 60)
+
+    width, height = 24, 24
+    pixels = make_solid_rgba(width, height, 255, 0, 255)
+
+    # Write into the system temp dir with a recognizable filename.
+    filename = f"kitty_test_{os.getpid()}.rgba"
+    tmp_dir = tempfile.gettempdir()
+    full_path = os.path.join(tmp_dir, filename)
+    with open(full_path, "wb") as f:
+        f.write(pixels)
+
+    # For t=t, the payload is the *relative* path under the temp dir.
+    path_b64 = base64.standard_b64encode(filename.encode()).decode("ascii")
+    responses = write_apc(f"a=T,t=t,f=32,s={width},v={height},i=61;{path_b64}")
+
+    if responses and "OK" in responses[0]:
+        print(f"  ✓ Temp file medium — terminal read {filename}")
+    elif responses:
+        print(f"  ⚠ Response: {responses[0]!r}")
+    else:
+        print(f"  ✓ Sent temp file medium command")
+
+    # Check if the terminal deleted the file (as it should).
+    time.sleep(0.2)
+    if os.path.exists(full_path):
+        print(f"  ⚠ File still exists (terminal should have deleted it): {full_path}")
+        os.unlink(full_path)
+    else:
+        print(f"  ✓ File was deleted by the terminal after reading")
+
+    print("  You should see a 24x24 magenta square above.\n")
+
+
+def test_shm_medium():
+    """Phase 2A: Transmit+display via shared memory medium (t=s).
+
+    Creates a POSIX shared memory object, writes pixel data, then tells
+    the terminal to mmap and read it.
+
+    Only works on Unix (macOS / Linux).
+    """
+    print("═" * 60)
+    print("TEST: Shared memory medium (t=s) — 16x16 solid cyan")
+    print("═" * 60)
+
+    if sys.platform == "win32":
+        print("  ⚠ Skipped — POSIX shm not available on Windows\n")
+        return
+
+    width, height = 16, 16
+    pixels = make_solid_rgba(width, height, 0, 255, 255)
+
+    shm_name = f"/kitty_test_{os.getpid()}"
+    try:
+        # Use ctypes to call shm_open / ftruncate / mmap.
+        libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+
+        O_CREAT = 0o100  # May differ per platform; we'll use the os module.
+        O_RDWR = os.O_RDWR
+
+        # shm_open returns an fd.
+        fd = libc.shm_open(
+            shm_name.encode(),
+            O_RDWR | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+        if fd < 0:
+            errno = ctypes.get_errno()
+            print(f"  ✗ shm_open failed: errno={errno}")
+            return
+
+        os.ftruncate(fd, len(pixels))
+
+        # mmap and write.
+        mm = mmap.mmap(fd, len(pixels), access=mmap.ACCESS_WRITE)
+        mm.write(pixels)
+        mm.close()
+        os.close(fd)
+
+        # Payload is the base64-encoded shm name.
+        name_b64 = base64.standard_b64encode(shm_name.encode()).decode("ascii")
+        responses = write_apc(f"a=T,t=s,f=32,s={width},v={height},i=62;{name_b64}")
+
+        if responses and "OK" in responses[0]:
+            print(f"  ✓ SHM medium — terminal read {shm_name}")
+        elif responses:
+            print(f"  ⚠ Response: {responses[0]!r}")
+        else:
+            print(f"  ✓ Sent shm medium command (name={shm_name})")
+
+        # Terminal should have shm_unlink'd. Check by trying to open it.
+        time.sleep(0.2)
+        fd2 = libc.shm_open(shm_name.encode(), os.O_RDONLY, 0)
+        if fd2 >= 0:
+            os.close(fd2)
+            print(f"  ⚠ SHM still exists (terminal should have unlinked it)")
+            libc.shm_unlink(shm_name.encode())
+        else:
+            print(f"  ✓ SHM was unlinked by the terminal after reading")
+
+    except Exception as e:
+        print(f"  ✗ Error: {e}")
+        # Try to clean up.
+        try:
+            libc.shm_unlink(shm_name.encode())
+        except Exception:
+            pass
+
+    print("  You should see a 16x16 cyan square above.\n")
+
+
+# ── Phase 2: Full Delete Modes ─────────────────────────────────────────
+
+
+def test_delete_modes():
+    """Phase 2B: Exercise all delete target modes.
+
+    Places several images at different locations, then deletes them using
+    various d= modes and reports the results.
+    """
+    print("═" * 60)
+    print("TEST: Full delete modes (d=a, d=i, d=n, d=p, d=c, d=z)")
+    print("═" * 60)
+
+    def place(image_id, width, height, r, g, b, **extra):
+        """Helper to place a solid-color image."""
+        pixels = make_solid_rgba(width, height, r, g, b)
+        kv_extra = ",".join(f"{k}={v}" for k, v in extra.items())
+        kv = f"a=T,f=32,s={width},v={height},i={image_id}"
+        if kv_extra:
+            kv += f",{kv_extra}"
+        write_chunked(kv, pixels)
+
+    # Place a row of small images.
+    print("  Placing 5 small images (id=70..74)...")
+    place(70, 12, 12, 255, 0, 0)      # red
+    place(71, 12, 12, 0, 255, 0)      # green
+    place(72, 12, 12, 0, 0, 255)      # blue
+    place(73, 12, 12, 255, 255, 0)    # yellow
+    place(74, 12, 12, 255, 0, 255)    # magenta
+    print()
+
+    # Delete by ID.
+    write_apc("a=d,d=i,i=70", expect_response=False)
+    print("  ✓ d=i,i=70 — deleted red square by ID")
+
+    # Delete by image number — first we need one with I= set.
+    pixels_white = make_solid_rgba(12, 12, 255, 255, 255)
+    write_chunked("a=T,f=32,s=12,v=12,i=75,I=500", pixels_white)
+    write_apc("a=d,d=n,I=500", expect_response=False)
+    print("  ✓ d=n,I=500 — deleted white square by number mapping")
+
+    # Delete by placement ID.
+    place(76, 12, 12, 128, 128, 128, p=99)
+    write_apc("a=d,d=p,i=76,p=99", expect_response=False)
+    print("  ✓ d=p,i=76,p=99 — deleted grey square by placement ID")
+
+    # Delete at cursor position (d=c).
+    place(77, 12, 12, 0, 128, 128)
+    write_apc("a=d,d=c", expect_response=False)
+    print("  ✓ d=c — deleted teal square at cursor position")
+
+    # Delete by z-index.
+    place(78, 12, 12, 128, 0, 128, z=42)
+    write_apc("a=d,d=z,z=42", expect_response=False)
+    print("  ✓ d=z,z=42 — deleted purple square by z-index")
+
+    # Delete all remaining.
+    write_apc("a=d,d=a", expect_response=False)
+    print("  ✓ d=a — deleted all remaining images")
+
+    print()
+    print("  All delete modes exercised. Images should be gone from")
+    print("  storage (visible squares may linger until cells redraw).\n")
+
+
+# ── Phase 2: Scaling & Pixel Offsets ────────────────────────────────────
+
+
+def test_scaling():
+    """Phase 2C: Cell-based scaling (c= / r= columns/rows).
+
+    Displays the same source image at several different cell sizes
+    so you can visually confirm scaling works.
+    """
+    print("═" * 60)
+    print("TEST: Cell-based scaling (c= / r= columns/rows)")
+    print("═" * 60)
+
+    # Use a 64x64 checkerboard as the source — easy to see scaling artifacts.
+    width, height = 64, 64
+    pixels = make_checkerboard_rgba(width, height, sq=8)
+
+    # 1. No scaling — natural size.
+    write_chunked(f"a=T,f=32,s={width},v={height},i=80", pixels)
+    print("  ✓ Natural size (64x64 pixels, no c=/r=)")
+    print()
+
+    # 2. Scale to 10 columns wide (proportional height).
+    write_chunked(f"a=T,f=32,s={width},v={height},i=81,c=10", pixels)
+    print("  ✓ Scaled to c=10 columns (proportional height)")
+    print()
+
+    # 3. Scale to 5 rows tall (proportional width).
+    write_chunked(f"a=T,f=32,s={width},v={height},i=82,r=5", pixels)
+    print("  ✓ Scaled to r=5 rows (proportional width)")
+    print()
+
+    # 4. Scale to exact 20 columns × 4 rows (may distort).
+    write_chunked(f"a=T,f=32,s={width},v={height},i=83,c=20,r=4", pixels)
+    print("  ✓ Scaled to c=20, r=4 (stretched)")
+    print()
+
+    # 5. Scale down to 3 columns × 3 rows.
+    write_chunked(f"a=T,f=32,s={width},v={height},i=84,c=3,r=3", pixels)
+    print("  ✓ Scaled to c=3, r=3 (thumbnail)")
+    print()
+
+    print("  You should see 5 checkerboards at different sizes above.\n")
+
+
+def test_offsets():
+    """Phase 2C: Sub-cell pixel offsets (X= / Y=).
+
+    Places the same image multiple times with different X=/Y= offsets.
+    The visual effect is subtle: the image shifts within its first cell.
+    """
+    print("═" * 60)
+    print("TEST: Sub-cell pixel offsets (X= / Y=)")
+    print("═" * 60)
+
+    width, height = 16, 16
+    pixels = make_solid_rgba(width, height, 255, 100, 0)
+
+    # 1. No offset — baseline.
+    write_chunked(f"a=T,f=32,s={width},v={height},i=85", pixels)
+    print("  ✓ No offset (baseline)")
+
+    # 2. X=4 — shift right 4 pixels.
+    write_chunked(f"a=T,f=32,s={width},v={height},i=86,X=4", pixels)
+    print("  ✓ X=4 (shifted right 4px)")
+
+    # 3. Y=4 — shift down 4 pixels.
+    write_chunked(f"a=T,f=32,s={width},v={height},i=87,Y=4", pixels)
+    print("  ✓ Y=4 (shifted down 4px)")
+
+    # 4. X=4,Y=4 — shift both.
+    write_chunked(f"a=T,f=32,s={width},v={height},i=88,X=4,Y=4", pixels)
+    print("  ✓ X=4,Y=4 (shifted right+down 4px)")
+    print()
+
+    print("  The four orange squares above should show progressive offset.")
+    print("  The effect is subtle at small offsets — look at alignment.\n")
+
+
+def test_crop_and_scale():
+    """Phase 2C: Crop source rect + scale to cells."""
+    print("═" * 60)
+    print("TEST: Crop (x/y/w/h) + Scale (c/r) combined")
+    print("═" * 60)
+
+    # 64x64 gradient: we'll crop a 32x32 quadrant then scale it.
+    width, height = 64, 64
+    pixels = make_gradient_rgba(width, height)
+
+    # Show the full image first for reference.
+    write_chunked(f"a=T,f=32,s={width},v={height},i=89", pixels)
+    print("  ✓ Full 64x64 gradient (reference)")
+    print()
+
+    # Crop top-left 32x32, display at natural size.
+    write_chunked(f"a=T,f=32,s={width},v={height},i=90,x=0,y=0,w=32,h=32", pixels)
+    print("  ✓ Cropped top-left 32x32")
+    print()
+
+    # Crop bottom-right 32x32, scale to 10 columns.
+    write_chunked(f"a=T,f=32,s={width},v={height},i=91,x=32,y=32,w=32,h=32,c=10", pixels)
+    print("  ✓ Cropped bottom-right 32x32, scaled to c=10")
+    print()
+
+    print("  You should see: full gradient, top-left quadrant, then")
+    print("  bottom-right quadrant scaled wider.\n")
+
+
+# ── Phase 2: Animation ─────────────────────────────────────────────────
+
+
+def test_animation():
+    """Phase 2D: Animation frames (a=f) and control (a=a).
+
+    Creates a base image, adds animation frames, and exercises
+    animation control commands.
+
+    NOTE: The render-loop timer tick is NOT implemented yet, so
+    frames won't auto-advance. This test verifies the protocol
+    parsing and state management work — you'll see the base image
+    but frames won't animate until Phase 2E (render loop).
+    """
+    print("═" * 60)
+    print("TEST: Animation frames (a=f) and control (a=a)")
+    print("  NOTE: Frames won't auto-advance (render loop is Phase 2E).")
+    print("  This test verifies protocol parsing + state management.")
+    print("═" * 60)
+
+    width, height = 32, 32
+
+    # 1. Transmit base image (frame 0) — solid red.
+    pixels_red = make_solid_rgba(width, height, 255, 0, 0)
+    write_chunked(f"a=T,f=32,s={width},v={height},i=100", pixels_red)
+    print("  ✓ Base image (frame 0): solid red, id=100")
+    print()
+
+    # 2. Add frame 1 — solid green, 200ms gap.
+    pixels_green = make_solid_rgba(width, height, 0, 255, 0)
+    encoded_green = base64.standard_b64encode(pixels_green).decode("ascii")
+    responses = write_apc(f"a=f,i=100,f=32,s={width},v={height},z=200;{encoded_green}")
+    if responses and "OK" in responses[0]:
+        print("  ✓ Frame 1 added: solid green, gap=200ms")
+    elif responses:
+        print(f"  ⚠ Frame 1 response: {responses[0]!r}")
+    else:
+        print("  ✓ Frame 1 sent: solid green, gap=200ms")
+
+    # 3. Add frame 2 — solid blue, 200ms gap.
+    pixels_blue = make_solid_rgba(width, height, 0, 0, 255)
+    encoded_blue = base64.standard_b64encode(pixels_blue).decode("ascii")
+    responses = write_apc(f"a=f,i=100,f=32,s={width},v={height},z=200;{encoded_blue}")
+    if responses and "OK" in responses[0]:
+        print("  ✓ Frame 2 added: solid blue, gap=200ms")
+    elif responses:
+        print(f"  ⚠ Frame 2 response: {responses[0]!r}")
+    else:
+        print("  ✓ Frame 2 sent: solid blue, gap=200ms")
+
+    # 4. Animation control: start playback (s=1).
+    write_apc("a=a,i=100,s=1", expect_response=False)
+    print("  ✓ Animation control: s=1 (start playback)")
+
+    # 5. Animation control: set loop count.
+    write_apc("a=a,i=100,v=3", expect_response=False)
+    print("  ✓ Animation control: v=3 (loop 3 times)")
+
+    # 6. Animation control: stop (s=3).
+    write_apc("a=a,i=100,s=3", expect_response=False)
+    print("  ✓ Animation control: s=3 (stop / set to loading)")
+
+    print()
+    print("  You should see a red square above (base frame).")
+    print("  Frames are stored but won't auto-cycle until render loop")
+    print("  is implemented (Phase 2E).\n")
+
+
+def test_animation_compose():
+    """Phase 2D: Frame composition (a=c).
+
+    Creates a base image with frames, then uses compose to copy
+    pixels between frames.
+    """
+    print("═" * 60)
+    print("TEST: Animation frame composition (a=c)")
+    print("═" * 60)
+
+    width, height = 16, 16
+
+    # Base image.
+    pixels = make_solid_rgba(width, height, 100, 100, 100)
+    write_chunked(f"a=T,f=32,s={width},v={height},i=101", pixels)
+
+    # Add a second frame.
+    frame_pixels = make_solid_rgba(width, height, 200, 50, 50)
+    encoded = base64.standard_b64encode(frame_pixels).decode("ascii")
+    write_apc(f"a=f,i=101,f=32,s={width},v={height};{encoded}")
+    print("  ✓ Base + 1 frame created for image id=101")
+
+    # Compose: copy frame 0 onto frame 1 (c=0 base frame, r=1 target frame).
+    responses = write_apc("a=c,i=101,c=0,r=1")
+    if responses and "OK" in responses[0]:
+        print("  ✓ Composed: copied frame 0 → frame 1")
+    elif responses:
+        print(f"  ⚠ Compose response: {responses[0]!r}")
+    else:
+        print("  ✓ Compose command sent (frame 0 → frame 1)")
+
+    print("  Frame composition exercised.\n")
+
+
+# ── Phase 2: Combined / Stress Tests ───────────────────────────────────
+
+
+def test_file_with_offset_size():
+    """Phase 2A: File medium with S= (size) and O= (offset)."""
+    print("═" * 60)
+    print("TEST: File medium with offset+size (t=f, S=, O=)")
+    print("═" * 60)
+
+    width, height = 4, 4
+    # Write 64 bytes of pixel data, but prepend 16 bytes of junk.
+    junk = bytes(range(16))
+    pixels = make_solid_rgba(width, height, 0, 255, 128)
+    payload = junk + pixels + junk  # junk | real data | junk
+
+    with tempfile.NamedTemporaryFile(suffix=".rgba", delete=False) as f:
+        f.write(payload)
+        tmp_path = f.name
+
+    # Tell terminal to skip 16 bytes (O=16) and read 64 bytes (S=64).
+    path_b64 = base64.standard_b64encode(tmp_path.encode()).decode("ascii")
+    responses = write_apc(
+        f"a=T,t=f,f=32,s={width},v={height},i=110,O=16,S=64;{path_b64}"
+    )
+
+    if responses and "OK" in responses[0]:
+        print(f"  ✓ File with O=16, S=64 — read {tmp_path}")
+    elif responses:
+        print(f"  ⚠ Response: {responses[0]!r}")
+    else:
+        print(f"  ✓ Sent file medium with offset/size")
+
+    os.unlink(tmp_path)
+    print("  You should see a tiny 4x4 green square above.\n")
+
+
+def test_tempfile_path_traversal():
+    """Phase 2A: Verify that path traversal in t=t is rejected."""
+    print("═" * 60)
+    print("TEST: Temp file path traversal rejection (t=t, ../)")
+    print("═" * 60)
+
+    evil_path = "../../../etc/passwd"
+    path_b64 = base64.standard_b64encode(evil_path.encode()).decode("ascii")
+    responses = write_apc(f"a=T,t=t,f=32,s=1,v=1,i=111;{path_b64}")
+
+    if responses:
+        resp = responses[0]
+        if "OK" not in resp:
+            print(f"  ✓ Path traversal rejected: {resp!r}")
+        else:
+            print(f"  ✗ Path traversal was NOT rejected! Got OK.")
+    else:
+        print("  ⚠ No response (may be quiet mode — check debug log)")
+    print()
+
+
+# ── Test Group Runners ──────────────────────────────────────────────────
+
+
+def run_phase1():
+    """Run all Phase 1 tests."""
+    print()
+    print("╔══════════════════════════════════════════════════════════╗")
+    print("║          Phase 1 — Basic Protocol Tests                 ║")
+    print("╚══════════════════════════════════════════════════════════╝")
+    print()
+    test_query()
+    test_rgba()
+    test_rgb()
+    test_png()
+    test_chunked()
+    test_zlib()
+    test_transmit_then_display()
+    test_delete()
+    test_quiet_modes()
+    test_cursor_no_move()
+
+
+def run_phase2():
+    """Run all Phase 2 tests."""
+    print()
+    print("╔══════════════════════════════════════════════════════════╗")
+    print("║          Phase 2 — Advanced Protocol Tests              ║")
+    print("║                                                         ║")
+    print("║  A: File / TempFile / SHM transmission                  ║")
+    print("║  B: Full delete modes                                   ║")
+    print("║  C: Scaling (c=/r=) and pixel offsets (X=/Y=)           ║")
+    print("║  D: Animation frames + control                          ║")
+    print("╚══════════════════════════════════════════════════════════╝")
+    print()
+
+    # Stream A: Transmission mediums.
+    test_file_medium()
+    test_tempfile_medium()
+    test_shm_medium()
+    test_file_with_offset_size()
+    test_tempfile_path_traversal()
+
+    # Stream B: Delete modes.
+    test_delete_modes()
+
+    # Stream C: Scaling & offsets.
+    test_scaling()
+    test_offsets()
+    test_crop_and_scale()
+
+    # Stream D: Animation.
+    test_animation()
+    test_animation_compose()
+
+
 def run_all():
     """Run all tests in sequence."""
     print()
@@ -370,19 +921,14 @@ def run_all():
     print("╚══════════════════════════════════════════════════════════╝")
     print()
 
-    test_query()
-    test_rgba()
-    test_rgb()
-    test_png()
-    test_chunked()
-    test_zlib()
-    test_transmit_then_display()
-    test_delete()
-    test_quiet_modes()
-    test_cursor_no_move()
+    run_phase1()
+    run_phase2()
 
     print("═" * 60)
     print("ALL TESTS SENT.")
+    print()
+    print("Phase 1: Basic display, chunked transfer, query, quiet modes")
+    print("Phase 2: File/shm mediums, delete modes, scaling, animation")
     print()
     print("If you see colored squares above, the protocol is working!")
     print("If you only see text, check the debug log output:")
@@ -396,6 +942,7 @@ if __name__ == "__main__":
     else:
         cmd = sys.argv[1]
         dispatch = {
+            # Phase 1.
             "query": test_query,
             "rgba": test_rgba,
             "rgb": test_rgb,
@@ -406,6 +953,21 @@ if __name__ == "__main__":
             "delete": test_delete,
             "quiet": test_quiet_modes,
             "cursor": test_cursor_no_move,
+            "phase1": run_phase1,
+            # Phase 2.
+            "file_medium": test_file_medium,
+            "tempfile_medium": test_tempfile_medium,
+            "shm_medium": test_shm_medium,
+            "file_offset": test_file_with_offset_size,
+            "tempfile_traversal": test_tempfile_path_traversal,
+            "delete_modes": test_delete_modes,
+            "scaling": test_scaling,
+            "offsets": test_offsets,
+            "crop_scale": test_crop_and_scale,
+            "animation": test_animation,
+            "animation_compose": test_animation_compose,
+            "phase2": run_phase2,
+            # All.
             "all": run_all,
         }
 


### PR DESCRIPTION
This PR adds kitty graphics protocol support to the `graphics` branch, building on top of the existing sixel infrastructure. The key insight driving the implementation is that `GraphicData` is protocol-agnostic — once kitty's APC payload is decoded into a pixel buffer, the entire GPU pipeline (texture upload, cell attachment, shader rendering) works identically to sixel. No renderer changes were needed.

### Method

Analyse [kovid's spec](https://sw.kovidgoyal.net/kitty/graphics-protocol/), wezterm, ghostty, and alacritty-graphics. Turns out not a lot, mostly encoding/decoding machinery, which I generated (see [docs](https://github.com/dsturnbull/alacritty/blob/alacritty-kitty/docs/kitty_graphics_plan.md))



### Architecture

```
                       ┌──── DCS 'q' ──► sixel::Parser ──┐
 PTY ──► vte-graphics ─┤                                  ├──► GraphicData
                       └──── APC 'G' ──► kitty::Parser ──┘         │
                                 │                                 ▼
                                 │ (responses)              insert_graphic()
                                 ▼                                 │
                           PTY write-back                          ▼
                           ESC _Gi=N;OK                    Grid cells get
                                                           GraphicCell refs
                                                                   │
                                                                   ▼
           display::draw() ──► take_queues() ──► GPU upload ──► shader
```

The new code lives entirely in `alacritty_terminal`. The rendering side (`alacritty/src/display/`) is untouched — kitty images flow through the same `insert_graphic()` → `GraphicCell` → texture upload → fragment shader path that sixel already uses.

### What's implemented

**APC routing** — `vte-graphics` is patched ([dsturnbull/vte@kitty](https://github.com/dsturnbull/vte/tree/kitty)) to dispatch `apc_start`/`apc_put`/`apc_end`, following the same pattern as the existing DCS hooks. The VTE state machine already recognised the `APC_STRING` state; it just wasn't wired to callbacks.

**Key-value parser** (`kitty_parser.rs`, ~800 LOC) — Streaming parser for the `ESC _G<key>=<value>[,...];<payload>ESC \` format. Handles all documented protocol fields including the overloaded animation keys (`c=`/`r=`/`z=` mean different things in frame context vs display context).

**Transmission mediums** (`decode.rs`, ~1100 LOC):
- `t=d` Direct — inline base64, with lenient padding handling for clients like chafa that independently encode each chunk
- `t=f` File — base64-encoded file path with offset/size support
- `t=t` Temp file — relative to `$TMPDIR`, auto-deleted after read, path traversal validation rejects `../` and absolute paths
- `t=s` Shared memory — POSIX `shm_open` + `mmap`, `shm_unlink` after read (unix-gated)

**Decode pipeline**: base64 → zlib (optional, `o=z`) → format dispatch (RGB `f=24`, RGBA `f=32`, PNG `f=100`) → `GraphicData`. Chunked transfers (`m=0`/`m=1`) decode each chunk's base64 on arrival rather than concatenating base64 strings, which handles the chafa per-chunk-padding case correctly.

**Image storage** (`state.rs`, ~1060 LOC) — `HashMap<u32, KittyImage>` with 320 MiB quota and LRU eviction (matching kitty/ghostty/wezterm). Image number (`I=`) → image ID (`i=`) mapping. All 11 delete target pairs:

| Target | Pairs | Description |
|--------|-------|-------------|
| All | `d=a/A` | Clear all images |
| By ID | `d=i/I` | Delete by image ID |
| By number | `d=n/N` | Delete by image number |
| Cursor | `d=c/C` | Delete at cursor position |
| Column | `d=q/Q` | Delete intersecting column |
| Row | `d=r/R` | Delete intersecting row |
| Cell | `d=x/X` | Delete at specific cell |
| Cell+Z | `d=y/Y` | Delete at cell with z-index match |
| Z-index | `d=z/Z` | Delete by z-index |
| Placement | `d=p/P` | Delete by placement ID |
| Anim frame | `d=f/F` | Delete animation frames |

The `IncludingScrollback` (uppercase) variants clean up orphaned images from storage.

**Placement** (`placement.rs`, ~600 LOC) — Source rectangle cropping (`x=`/`y=`/`w=`/`h=`), cell-based scaling (`c=`/`r=` via bilinear resize), sub-cell pixel offsets (`X=`/`Y=` via transparent padding), cursor movement control (`C=1`). Pipeline: crop → scale → offset → `insert_graphic`.

**Animation** (`animation.rs`, ~1120 LOC) — Frame storage with lazy single→multi-frame promotion (following the WezTerm pattern). `a=f` loads frames with base-frame copy and positional blitting. `a=c` composites between frames (alpha blending and overwrite modes). `a=a` controls playback (start/stop/loading, loop count). Note: the animation *tick* loop (advancing frames on a timer and re-uploading textures) is not yet wired into the display event loop — frames are stored and composed but not auto-advanced.

**Protocol responses** (`response.rs`) — `ESC _Gi=<id>;OK ESC \` / `ESC _Gi=<id>;EINVAL:<msg> ESC \` via `Event::PtyWrite`. Respects `q=1` (suppress OK) and `q=2` (suppress all). No response when `i=0` and `I=0` (matching kitty's `finish_command_response` behaviour).

### Testing

184 `#[test]` functions across the modules:
- 13 end-to-end integration tests that feed raw APC bytes through the full VTE → Parser → Term → dispatch pipeline and verify state
- Unit tests across all streams (decode, state, placement, animation, response, parser)
- `scripts/test_kitty_graphics.py` — 25 manual protocol-level tests with visual ✓/✗ feedback (query, PNG, chunked, file/tempfile/shm mediums, delete modes, scaling, pixel offsets, animation frames)
- `scripts/demo_kitty_graphics.sh` — real-world validation with timg, chafa, and mpv

### What works end-to-end

- `timg -p kitty image.png` ✓
- `timg -p kitty animation.gif` ✓
- `chafa -f kitty image.png` ✓
- `kitty +kitten icat image.png` ✓ (chunked PNG transfer)
- Direct RGBA/RGB transmission ✓
- File and shared memory transmission ✓
- Placement, cropping, scaling, pixel offsets ✓
- Delete by all target types ✓

### New dependencies

| Crate | Purpose |
|-------|---------|
| `flate2` 1.1 | zlib decompression (`o=z`) |
| `png` 0.18 | PNG decoding (`f=100`) — also fixes a breaking API change in the window icon loader |
| `image` 0.25 (minimal, png+rayon features) | Bilinear scaling for `c=`/`r=` cell-based resize |
| `tempfile` 3 (dev) | Integration tests for temp file medium |

### Segfaults with mpv video playback — looking for input

`mpv --vo=kitty` and `timg -V` (video mode) send images at 30+ fps, effectively stress-testing the graphics pipeline. Under this load, both tools reliably trigger a segfault in `mpv`. *n.b. this also happens in ghostty!*
